### PR TITLE
Add Line2D-Rect2D intersection to Rect2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Rect2D` now has `Line2D` intersection members, each with a curried-free static counterpart taking the rectangle first, and an optional tolerance (default `1e-6`) that enlarges the rectangle on each side so lines grazing an edge or corner still count:
+  - `Intersects`, `IntersectionPoints` and `IntersectionLine` treat the `Line2D` as its finite segment.
+  - `RayIntersects`, `RayIntersectionPoints` and `RayIntersectionLine` treat the `Line2D` as an infinite line in both directions.
 
 ## [0.42.0] - 2026-06-20
 ### Added

--- a/Src/Rect2D.fs
+++ b/Src/Rect2D.fs
@@ -1913,6 +1913,176 @@ type Rect2D =
         r.GetEdge i
 
     // #endregion
+    // #region Line Intersection
+
+    /// Internal Liang–Barsky clip of a 2D line against this 2D Rectangle.
+    /// The rectangle is enlarged by 'tol' on each side so that lines grazing an edge or corner still count as touching.
+    /// If 'asRay' is TRUE the line is treated as infinite in both directions, otherwise as the finite segment From-To.
+    /// Returns the two endpoints (x0,y0,x1,y1) of the portion inside the rectangle, or ValueNone if it is fully outside.
+    /// Fails if the rectangle has a zero length axis or the line is too short.
+    static member private clipLine2D (r:Rect2D, line:Line2D, asRay:bool, tol:float) : ValueOption<struct(float*float*float*float)> =
+        let xlenSq = r.XaxisX*r.XaxisX + r.XaxisY*r.XaxisY
+        let ylenSq = r.YaxisX*r.YaxisX + r.YaxisY*r.YaxisY
+        if isTooSmallSq xlenSq then failTooSmall "Rect2D line intersection: Xaxis" r
+        if isTooSmallSq ylenSq then failTooSmall "Rect2D line intersection: Yaxis" r
+        let xlen = sqrt xlenSq
+        let ylen = sqrt ylenSq
+        let uxx = r.XaxisX / xlen // unit X-axis of the rectangle
+        let uxy = r.XaxisY / xlen
+        let uyx = r.YaxisX / ylen // unit Y-axis of the rectangle
+        let uyy = r.YaxisY / ylen
+        let vx = line.ToX - line.FromX
+        let vy = line.ToY - line.FromY
+        let lenSq = vx*vx + vy*vy
+        if isTooSmallSq lenSq then failTooSmall "Rect2D line intersection: line is too short" line
+        let len = sqrt lenSq
+        let ndx = vx / len // unit direction of the line
+        let ndy = vy / len
+        let ox = line.FromX - r.OriginX
+        let oy = line.FromY - r.OriginY
+        let p0u = ox*uxx + oy*uxy   // local X distance of the From point
+        let p0v = ox*uyx + oy*uyy   // local Y distance of the From point
+        let du  = ndx*uxx + ndy*uxy // local X component of the unit direction
+        let dv  = ndx*uyx + ndy*uyy // local Y component of the unit direction
+        // Liang–Barsky: walk the line parameter t (a distance because the direction is unitized)
+        // from tE (entering) to tL (leaving). Each box boundary is an inequality  p*t <= q .
+        // 'tol' enlarges the box by that distance on all four sides.
+        let mutable tE = if asRay then -infinity else 0.0
+        let mutable tL = if asRay then  infinity else len
+        let mutable ok = true
+        let mutable p = -du                  // boundary  local-X >= -tol
+        let mutable q = p0u + tol
+        if   abs p <= 1e-12 then (if q < 0.0 then ok <- false)
+        elif p < 0.0        then (let t = q/p in if t > tL then ok <- false elif t > tE then tE <- t)
+        else                     (let t = q/p in if t < tE then ok <- false elif t < tL then tL <- t)
+        p <- du                              // boundary  local-X <= xlen + tol
+        q <- xlen + tol - p0u
+        if   abs p <= 1e-12 then (if q < 0.0 then ok <- false)
+        elif p < 0.0        then (let t = q/p in if t > tL then ok <- false elif t > tE then tE <- t)
+        else                     (let t = q/p in if t < tE then ok <- false elif t < tL then tL <- t)
+        p <- -dv                             // boundary  local-Y >= -tol
+        q <- p0v + tol
+        if   abs p <= 1e-12 then (if q < 0.0 then ok <- false)
+        elif p < 0.0        then (let t = q/p in if t > tL then ok <- false elif t > tE then tE <- t)
+        else                     (let t = q/p in if t < tE then ok <- false elif t < tL then tL <- t)
+        p <- dv                              // boundary  local-Y <= ylen + tol
+        q <- ylen + tol - p0v
+        if   abs p <= 1e-12 then (if q < 0.0 then ok <- false)
+        elif p < 0.0        then (let t = q/p in if t > tL then ok <- false elif t > tE then tE <- t)
+        else                     (let t = q/p in if t < tE then ok <- false elif t < tL then tL <- t)
+        if ok && tE <= tL then
+            ValueSome (struct(line.FromX + tE*ndx, line.FromY + tE*ndy, line.FromX + tL*ndx, line.FromY + tL*ndy))
+        else
+            ValueNone
+
+    /// <summary>Tests if a finite 2D line (the segment From-To) touches or crosses this 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance, so a line grazing an edge or corner still counts.</summary>
+    /// <param name="line">The finite 2D line to test against this rectangle.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>TRUE if any part of the line segment lies inside the (tolerance enlarged) rectangle. Otherwise FALSE.</returns>
+    member r.Intersects(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : bool =
+        match Rect2D.clipLine2D(r, line, false, tol) with
+        | ValueSome _ -> true
+        | ValueNone   -> false
+
+    /// <summary>Returns the points where a finite 2D line (the segment From-To) enters and leaves this 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance, so a line grazing an edge or corner still counts.
+    /// The returned points are the endpoints of the portion of the line inside the rectangle, so a segment
+    /// endpoint that lies inside the rectangle is returned as such.</summary>
+    /// <param name="line">The finite 2D line to intersect with this rectangle.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>An array of 0, 1 or 2 points: empty if the line is fully outside, one point if it just grazes a corner
+    /// (within the tolerance), otherwise the two points bounding the inside portion.</returns>
+    member r.IntersectionPoints(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Pt[] =
+        match Rect2D.clipLine2D(r, line, false, tol) with
+        | ValueNone -> [| |]
+        | ValueSome (struct(x0,y0,x1,y1)) ->
+            let dx = x1-x0
+            let dy = y1-y0
+            if dx*dx + dy*dy <= tol*tol then [| Pt((x0+x1)*0.5, (y0+y1)*0.5) |] // the line only grazes a corner
+            else [| Pt(x0,y0); Pt(x1,y1) |]
+
+    /// <summary>Returns the portion of a finite 2D line (the segment From-To) that lies inside this 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance, so a line grazing an edge or corner still counts.</summary>
+    /// <param name="line">The finite 2D line to clip to this rectangle.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>ValueSome with the clipped 2D line if any part lies inside the rectangle (this may be a zero length line
+    /// if the line only grazes a corner). ValueNone if the line is fully outside.</returns>
+    member r.IntersectionLine(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Line2D voption =
+        match Rect2D.clipLine2D(r, line, false, tol) with
+        | ValueNone -> ValueNone
+        | ValueSome (struct(x0,y0,x1,y1)) -> ValueSome (Line2D(x0,y0,x1,y1))
+
+    /// <summary>Tests if the infinite 2D line through the given finite line touches or crosses this 2D Rectangle.
+    /// The line is extended infinitely in both directions. The rectangle is enlarged by the tolerance, so a line
+    /// grazing an edge or corner still counts.</summary>
+    /// <param name="line">A finite 2D line defining the infinite line by its start point and direction.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>TRUE if the infinite line passes through the (tolerance enlarged) rectangle. Otherwise FALSE.</returns>
+    member r.RayIntersects(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : bool =
+        match Rect2D.clipLine2D(r, line, true, tol) with
+        | ValueSome _ -> true
+        | ValueNone   -> false
+
+    /// <summary>Returns the points where the infinite 2D line through the given finite line enters and leaves this 2D Rectangle.
+    /// The line is extended infinitely in both directions. The rectangle is enlarged by the tolerance, so a line
+    /// grazing an edge or corner still counts.</summary>
+    /// <param name="line">A finite 2D line defining the infinite line by its start point and direction.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>An array of 0, 1 or 2 points: empty if the line misses the rectangle, one point if it just grazes a corner
+    /// (within the tolerance), otherwise the two boundary points.</returns>
+    member r.RayIntersectionPoints(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Pt[] =
+        match Rect2D.clipLine2D(r, line, true, tol) with
+        | ValueNone -> [| |]
+        | ValueSome (struct(x0,y0,x1,y1)) ->
+            let dx = x1-x0
+            let dy = y1-y0
+            if dx*dx + dy*dy <= tol*tol then [| Pt((x0+x1)*0.5, (y0+y1)*0.5) |] // the line only grazes a corner
+            else [| Pt(x0,y0); Pt(x1,y1) |]
+
+    /// <summary>Returns the chord of the infinite 2D line through the given finite line inside this 2D Rectangle.
+    /// The line is extended infinitely in both directions. The rectangle is enlarged by the tolerance, so a line
+    /// grazing an edge or corner still counts.</summary>
+    /// <param name="line">A finite 2D line defining the infinite line by its start point and direction.</param>
+    /// <param name="tol">Optional tolerance, default 1e-6. The rectangle is enlarged by this distance on each of its four sides.</param>
+    /// <returns>ValueSome with the chord as a 2D line if the infinite line passes through the rectangle (this may be a
+    /// zero length line if it only grazes a corner). ValueNone if the line misses the rectangle.</returns>
+    member r.RayIntersectionLine(line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Line2D voption =
+        match Rect2D.clipLine2D(r, line, true, tol) with
+        | ValueNone -> ValueNone
+        | ValueSome (struct(x0,y0,x1,y1)) -> ValueSome (Line2D(x0,y0,x1,y1))
+
+    /// Tests if a finite 2D line (the segment From-To) touches or crosses the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member intersects (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : bool =
+        rect.Intersects(line, tol)
+
+    /// Returns the 0, 1 or 2 points where a finite 2D line (the segment From-To) enters and leaves the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member intersectionPoints (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Pt[] =
+        rect.IntersectionPoints(line, tol)
+
+    /// Returns the portion of a finite 2D line (the segment From-To) that lies inside the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member intersectionLine (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Line2D voption =
+        rect.IntersectionLine(line, tol)
+
+    /// Tests if the infinite 2D line through the given finite line touches or crosses the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member rayIntersects (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : bool =
+        rect.RayIntersects(line, tol)
+
+    /// Returns the 0, 1 or 2 points where the infinite 2D line through the given finite line enters and leaves the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member rayIntersectionPoints (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Pt[] =
+        rect.RayIntersectionPoints(line, tol)
+
+    /// Returns the chord of the infinite 2D line through the given finite line inside the 2D Rectangle.
+    /// The rectangle is enlarged by the tolerance (default 1e-6), so a line grazing an edge or corner still counts.
+    static member rayIntersectionLine (rect:Rect2D, line:Line2D, [<OPT;DEF(1e-6)>] tol:float) : Line2D voption =
+        rect.RayIntersectionLine(line, tol)
+
+    // #endregion
     // #region Obsolete
 
     [<Obsolete("use SizeX")>]

--- a/Src/Rect2D.fs
+++ b/Src/Rect2D.fs
@@ -1921,6 +1921,11 @@ type Rect2D =
     /// Returns the two endpoints (x0,y0,x1,y1) of the portion inside the rectangle, or ValueNone if it is fully outside.
     /// Fails if the rectangle has a zero length axis or the line is too short.
     static member private clipLine2D (r:Rect2D, line:Line2D, asRay:bool, tol:float) : ValueOption<struct(float*float*float*float)> =
+        // The rectangle may be rotated, so instead of clipping in world space we clip in the
+        // rectangle's own local frame, where it becomes the axis-aligned box [0,xlen] x [0,ylen].
+        // A point P maps to local coordinates  u = (P-Origin)·Xunit  and  v = (P-Origin)·Yunit .
+
+        // Step 1: the rectangle's two unit axes and their lengths (= the local box size). Fail on a degenerate axis.
         let xlenSq = r.XaxisX*r.XaxisX + r.XaxisY*r.XaxisY
         let ylenSq = r.YaxisX*r.YaxisX + r.YaxisY*r.YaxisY
         if isTooSmallSq xlenSq then failTooSmall "Rect2D line intersection: Xaxis" r
@@ -1931,6 +1936,9 @@ type Rect2D =
         let uxy = r.XaxisY / xlen
         let uyx = r.YaxisX / ylen // unit Y-axis of the rectangle
         let uyy = r.YaxisY / ylen
+
+        // Step 2: the line's unit direction. Unitizing means the parameter 't' below is a distance,
+        // so the parallel test and the corner-merging in the callers can use 'tol' directly. Fail on a zero length line.
         let vx = line.ToX - line.FromX
         let vy = line.ToY - line.FromY
         let lenSq = vx*vx + vy*vy
@@ -1938,15 +1946,27 @@ type Rect2D =
         let len = sqrt lenSq
         let ndx = vx / len // unit direction of the line
         let ndy = vy / len
+
+        // Step 3: express the line in the local frame as  point(t) = (p0u,p0v) + t*(du,dv) .
         let ox = line.FromX - r.OriginX
         let oy = line.FromY - r.OriginY
         let p0u = ox*uxx + oy*uxy   // local X distance of the From point
         let p0v = ox*uyx + oy*uyy   // local Y distance of the From point
         let du  = ndx*uxx + ndy*uxy // local X component of the unit direction
         let dv  = ndx*uyx + ndy*uyy // local Y component of the unit direction
-        // Liang–Barsky: walk the line parameter t (a distance because the direction is unitized)
-        // from tE (entering) to tL (leaving). Each box boundary is an inequality  p*t <= q .
-        // 'tol' enlarges the box by that distance on all four sides.
+
+        // Step 4: Liang–Barsky clipping. We shrink the parameter interval [tE,tL] (entering..leaving) by
+        // intersecting it with the four half-planes of the box. A finite segment starts as [0,len], an
+        // infinite ray as [-inf,+inf]. 'tol' enlarges the box by that distance on all four sides, so a line
+        // grazing an edge or corner is still kept. Each boundary is written as the inequality  p*t <= q :
+        //   local-X >= -tol        ->  -du*t <= p0u + tol
+        //   local-X <= xlen + tol  ->   du*t <= xlen + tol - p0u
+        //   local-Y >= -tol        ->  -dv*t <= p0v + tol
+        //   local-Y <= ylen + tol  ->   dv*t <= ylen + tol - p0v
+        // For each boundary, given the crossing parameter t = q/p:
+        //   p = 0 : the line is parallel to this boundary; it is entirely outside only if q < 0.
+        //   p < 0 : t is where the line ENTERS this half-plane -> raise tE (reject if it passes tL).
+        //   p > 0 : t is where the line LEAVES this half-plane -> lower tL (reject if it passes tE).
         let mutable tE = if asRay then -infinity else 0.0
         let mutable tL = if asRay then  infinity else len
         let mutable ok = true
@@ -1970,6 +1990,9 @@ type Rect2D =
         if   abs p <= 1e-12 then (if q < 0.0 then ok <- false)
         elif p < 0.0        then (let t = q/p in if t > tL then ok <- false elif t > tE then tE <- t)
         else                     (let t = q/p in if t < tE then ok <- false elif t < tL then tL <- t)
+
+        // Step 5: if the interval survived, map its two ends back to world coordinates (point(t) along the
+        // original line). tE = tL means the line only touches a single point, e.g. a corner.
         if ok && tE <= tL then
             ValueSome (struct(line.FromX + tE*ndx, line.FromY + tE*ndy, line.FromX + tL*ndx, line.FromY + tL*ndy))
         else

--- a/Test/TestRect2D.fs
+++ b/Test/TestRect2D.fs
@@ -670,4 +670,117 @@ let tests =
                 "has constructor" |> Expect.stringContains s "Rect2D.createUnchecked"
             }
         ]
+
+        // ---------------------------------------------------------------------
+        // Line2D - Rect2D intersection
+        // `rect` is the unit square (0,0)-(1,1). `rr` is the rotated rectangle
+        // with corners p0(5,3) p1(13,9) p2(10,13) p3(2,7) and center (7.5,8).
+        // ---------------------------------------------------------------------
+        testList "Line intersection" [
+
+            test "segment crossing the unit square (exact, tol 0)" {
+                let ln = Line2D(-1., 0.5, 2., 0.5) // horizontal through y = 0.5
+                "intersects" |> Expect.isTrue (rect.Intersects(ln, 0.0))
+                let pts = rect.IntersectionPoints(ln, 0.0)
+                "two points" |> Expect.equal pts.Length 2
+                "enter" |> Expect.isTrue (eq pts.[0] (Pt(0., 0.5)))
+                "leave" |> Expect.isTrue (eq pts.[1] (Pt(1., 0.5)))
+                match rect.IntersectionLine(ln, 0.0) with
+                | ValueSome l -> "clipped line" |> Expect.isTrue (eqLine l (Pt(0., 0.5)) (Pt(1., 0.5)))
+                | ValueNone   -> "should clip" |> Expect.isTrue false
+            }
+
+            test "segment fully inside is returned unchanged" {
+                let ln = Line2D(0.25, 0.5, 0.75, 0.5)
+                "intersects" |> Expect.isTrue (rect.Intersects ln)
+                match rect.IntersectionLine ln with
+                | ValueSome l -> "same line" |> Expect.isTrue (eqLine l (Pt(0.25, 0.5)) (Pt(0.75, 0.5)))
+                | ValueNone   -> "should clip" |> Expect.isTrue false
+            }
+
+            test "segment fully outside misses" {
+                let ln = Line2D(2., 0., 2., 1.) // vertical at x = 2
+                "no intersect" |> Expect.isFalse (rect.Intersects ln)
+                "no points" |> Expect.equal (rect.IntersectionPoints ln).Length 0
+                "no clipped line" |> Expect.isTrue ((rect.IntersectionLine ln).IsNone)
+                "ray also misses" |> Expect.isFalse (rect.RayIntersects ln)
+            }
+
+            test "finite segment outside but its ray crosses" {
+                let ln = Line2D(2., 0.5, 3., 0.5) // to the right of the square, pointing further right
+                "segment misses" |> Expect.isFalse (rect.Intersects ln)
+                "ray hits" |> Expect.isTrue (rect.RayIntersects ln)
+                let pts = rect.RayIntersectionPoints(ln, 0.0)
+                "ray two points" |> Expect.equal pts.Length 2
+                "ray enter" |> Expect.isTrue (eq pts.[0] (Pt(0., 0.5)))
+                "ray leave" |> Expect.isTrue (eq pts.[1] (Pt(1., 0.5)))
+            }
+
+            test "ray along the main diagonal hits both corners (exact, tol 0)" {
+                let ln = Line2D(-1., -1., 2., 2.) // infinite line through (0,0) and (1,1)
+                let pts = rect.RayIntersectionPoints(ln, 0.0)
+                "two corners" |> Expect.equal pts.Length 2
+                "corner 0,0" |> Expect.isTrue (eq pts.[0] (Pt(0., 0.)))
+                "corner 1,1" |> Expect.isTrue (eq pts.[1] (Pt(1., 1.)))
+                match rect.RayIntersectionLine(ln, 0.0) with
+                | ValueSome l -> "diagonal length" |> Expect.isTrue (eqf l.Length (sqrt 2.))
+                | ValueNone   -> "should clip" |> Expect.isTrue false
+            }
+
+            test "line grazing a single corner returns one point (tol 0)" {
+                let ln = Line2D(0., 2., 2., 0.) // x + y = 2, touches square only at (1,1)
+                "grazes" |> Expect.isTrue (rect.RayIntersects(ln, 0.0))
+                let pts = rect.RayIntersectionPoints(ln, 0.0)
+                "one point" |> Expect.equal pts.Length 1
+                "at corner" |> Expect.isTrue (eq pts.[0] (Pt(1., 1.)))
+                match rect.RayIntersectionLine(ln, 0.0) with
+                | ValueSome l -> "zero length at corner" |> Expect.isTrue (eqf l.Length 0.)
+                | ValueNone   -> "should touch" |> Expect.isTrue false
+            }
+
+            test "near-miss corner within tolerance is detected" {
+                // x + y = 2 + d ; the rectangle (enlarged by tol on each side) reaches a sum of 2 + 2*tol at its
+                // far corner, so the line is detected when d <= 2*tol. Default tol = 1e-6.
+                let inside  = Line2D(0., 2. + 1e-6, 2. + 1e-6, 0.) // d = 1e-6  < 2e-6 -> hit
+                let outside = Line2D(0., 2. + 3e-6, 2. + 3e-6, 0.) // d = 3e-6  > 2e-6 -> miss
+                "near miss counts" |> Expect.isTrue  (rect.RayIntersects inside)
+                "far miss ignored" |> Expect.isFalse (rect.RayIntersects outside)
+            }
+
+            test "line collinear with an edge returns the overlap (tol 0)" {
+                let ln = Line2D(-1., 0., 2., 0.) // along the bottom edge y = 0
+                "on edge intersects" |> Expect.isTrue (rect.Intersects(ln, 0.0))
+                match rect.IntersectionLine(ln, 0.0) with
+                | ValueSome l -> "edge overlap" |> Expect.isTrue (eqLine l (Pt(0., 0.)) (Pt(1., 0.)))
+                | ValueNone   -> "should overlap" |> Expect.isTrue false
+            }
+
+            test "crossing a rotated, off-origin rectangle (exact, tol 0)" {
+                // line through the center along the rectangle's local X-axis direction (0.8, 0.6)
+                let ln = Line2D(-0.5, 2., 15.5, 14.)
+                let pts = rr.RayIntersectionPoints(ln, 0.0)
+                "two points" |> Expect.equal pts.Length 2
+                "enter mid of left edge"  |> Expect.isTrue (eq pts.[0] (Pt(3.5, 5.)))
+                "leave mid of right edge" |> Expect.isTrue (eq pts.[1] (Pt(11.5, 11.)))
+                "segment also intersects" |> Expect.isTrue (rr.Intersects ln)
+                match rr.RayIntersectionLine(ln, 0.0) with
+                | ValueSome l -> "full width chord" |> Expect.isTrue (eqf l.Length 10.)
+                | ValueNone   -> "should clip" |> Expect.isTrue false
+            }
+
+            test "static functions delegate to instance members" {
+                let ln = Line2D(-1., 0.5, 2., 0.5)
+                "static intersects" |> Expect.isTrue (Rect2D.intersects(rect, ln, 0.0))
+                "static points" |> Expect.equal (Rect2D.intersectionPoints(rect, ln, 0.0)).Length 2
+                "static rayIntersects" |> Expect.isTrue (Rect2D.rayIntersects(rect, ln))
+                match Rect2D.intersectionLine(rect, ln, 0.0) with
+                | ValueSome l -> "static clipped line" |> Expect.isTrue (eqLine l (Pt(0., 0.5)) (Pt(1., 0.5)))
+                | ValueNone   -> "should clip" |> Expect.isTrue false
+            }
+
+            test "zero length line throws" {
+                let ln = Line2D(1., 1., 1., 1.)
+                "too short" |> Expect.throws (fun () -> rect.Intersects ln |> ignore)
+            }
+        ]
     ]


### PR DESCRIPTION
Add finite-segment and infinite-ray intersection members on Rect2D,
each with a static counterpart and an optional tolerance that enlarges
the rectangle so lines grazing an edge or corner still count:

- Intersects / IntersectionPoints / IntersectionLine (finite segment)
- RayIntersects / RayIntersectionPoints / RayIntersectionLine (infinite line)

Implemented as Liang-Barsky clipping in the rectangle's local frame, so
it works for rotated, off-origin rectangles. Boundary grazing a corner
collapses to a single point. Covered by tests for crossings, the
corner/edge tolerance cases, ray-vs-segment behavior, and degenerate
inputs, passing on both .NET and Fable/Node.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QxqvPVH7JyCCfBj8vk8bdS