### PR TITLE
Pin System.Text.Json to lowest supported version, exclude from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - dependency-type: "all"
     ignore:
       - dependency-name: "FSharp.Core"
+      - dependency-name: "System.Text.Json" # pinned to lowest version supporting net472, see Euclid.fsproj
 
     cooldown:
       default-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `CHECK_EUCLID` compiler symbol was renamed to `CHECKED_EUCLID`.
+- Pinned the `System.Text.Json` package reference (net472 only) to the lowest version providing the required APIs, `4.6.0`, instead of tracking latest, and excluded it from Dependabot version updates.
 
 ## [0.51.0] - 2026-07-28
 ### Added

--- a/Euclid.fsproj
+++ b/Euclid.fsproj
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.7" />
     <PackageReference Include="Fable.Core" Version="4.5.0"        Condition="$(DefineConstants.Contains('FABLE_COMPILER'))" />    <!-- Fable.Core only to use number.toFixed() and emitJSExpr -->
-    <PackageReference Include="System.Text.Json" Version="10.0.10"  Condition="'$(TargetFramework)' == 'net472' and !$(DefineConstants.Contains('FABLE_COMPILER'))" /> <!-- only on net472 runtime -->
+    <PackageReference Include="System.Text.Json" Version="4.6.0"  Condition="'$(TargetFramework)' == 'net472' and !$(DefineConstants.Contains('FABLE_COMPILER'))" /> <!-- only on net472 runtime; pinned to lowest version with the required APIs, excluded from Dependabot updates in .github/dependabot.yml -->
 
     <!-- build time only : -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />


### PR DESCRIPTION
The net472-only System.Text.Json reference was tracking the latest
release (10.0.10). Pin it to 4.6.0, the earliest stable release that
ships the netstandard2.0/net461 assets and the Utf8JsonWriter/
JsonSerializer APIs this project uses, and that predates all known
System.Text.Json CVEs (which only affect 6.0.x and 7.0.x-8.0.x).
Verified net472 still builds against it. Add it to dependabot.yml's
ignore list so it stays pinned instead of being bumped back up.