### PR TITLE
Add Polyline3D.TryPlane and Polyline3D.IsPlanar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
 - Added `Polyline3D.TryPlane` and `Polyline3D.IsPlanar`, plus the static `tryPlane` and `isPlanar`, to get the `NPlane` of a planar Polyline3D within a tolerance.
+- Added `Polyline3D.AveragePlane` and `Polyline3D.TryAveragePlane`, plus the static `averagePlane` and `tryAveragePlane`, to get the average `NPlane` of a Polyline3D even when its points are not planar.
+- Added `Polyline3D.TryAverageNormal` and the static `tryAverageNormal`, returning `None` where `AverageNormal` silently returns a zero length vector.
 - The unsafe internal constructors of `NPlane`, `PPlane`, `Box`, `BRect`, and `BBox`, and therefore all their `createUnchecked` members, now verify their input when compiled in DEBUG mode or with the `CHECKED_EUCLID` symbol defined. This covers unitized normals and axes, perpendicular and right-handed frames, `NaN` and `Infinity` values, and min values not being bigger than max values. The other unsafe constructors already did this.
 - Documented the `CHECKED_EUCLID` compiler flag in the Readme.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
+- Added `Polyline3D.TryPlane` and `Polyline3D.IsPlanar`, plus the static `tryPlane` and `isPlanar`, to get the `NPlane` of a planar Polyline3D within a tolerance.
 - The unsafe internal constructors of `NPlane`, `PPlane`, `Box`, `BRect`, and `BBox`, and therefore all their `createUnchecked` members, now verify their input when compiled in DEBUG mode or with the `CHECKED_EUCLID` symbol defined. This covers unitized normals and axes, perpendicular and right-handed frames, `NaN` and `Infinity` values, and min values not being bigger than max values. The other unsafe constructors already did this.
 - Documented the `CHECKED_EUCLID` compiler flag in the Readme.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
 - Added `Polyline3D.TryPlane` and `Polyline3D.IsPlanar`, plus the static `tryPlane` and `isPlanar`, to get the `NPlane` of a planar Polyline3D within a tolerance.
 - Added `Polyline3D.AveragePlane` and `Polyline3D.TryAveragePlane`, plus the static `averagePlane` and `tryAveragePlane`, to get the average `NPlane` of a Polyline3D even when its points are not planar.
-- Added `Polyline3D.TryAverageNormal` and the static `tryAverageNormal`, returning `None` where `AverageNormal` silently returns a zero length vector.
+- Added `Polyline3D.TryAverageNormal` and the static `tryAverageNormal`, returning `None` instead of failing where `AverageNormal` finds no normal.
 - The unsafe internal constructors of `NPlane`, `PPlane`, `Box`, `BRect`, and `BBox`, and therefore all their `createUnchecked` members, now verify their input when compiled in DEBUG mode or with the `CHECKED_EUCLID` symbol defined. This covers unitized normals and axes, perpendicular and right-handed frames, `NaN` and `Infinity` values, and min values not being bigger than max values. The other unsafe constructors already did this.
 - Documented the `CHECKED_EUCLID` compiler flag in the Readme.
 
 ### Changed
+- `Polyline3D.AverageNormal` now fails if no normal can be found, instead of silently returning an almost zero length vector. This is the case if the Polyline3D has less than 3 points, if all points are in one line, if the cross products cancel each other out on a self intersecting shape, or if the Polyline3D is very small. Use `Polyline3D.TryAverageNormal` to get `None` instead of an exception.
 - The `CHECK_EUCLID` compiler symbol was renamed to `CHECKED_EUCLID`.
 - Pinned the `System.Text.Json` package reference (net472 only) to the lowest version providing the required APIs, `4.6.0`, instead of tracking latest, and excluded it from Dependabot version updates.
 

--- a/Src/Polyline3D.fs
+++ b/Src/Polyline3D.fs
@@ -47,71 +47,109 @@ module private Polyline3DUtil =
         if ptCount < 3 then
             ValueNone
         else
-            // the center of all points is the origin of the plane
-            let mutable cx = 0.0
-            let mutable cy = 0.0
-            let mutable cz = 0.0
-            let mutable i = 0
             let len = xyzs.Count
+            // the center of all points is the origin of the plane
+            let mutable ox = 0.0
+            let mutable oy = 0.0
+            let mutable oz = 0.0
+            let mutable i = 0
             while i < len do
-                cx <- cx + xyzs.[i]
-                cy <- cy + xyzs.[i + 1]
-                cz <- cz + xyzs.[i + 2]
+                ox <- ox + xyzs.[i    ]
+                oy <- oy + xyzs.[i + 1]
+                oz <- oz + xyzs.[i + 2]
                 i <- i + 3
-            let cen = Pnt(cx / float ptCount, cy / float ptCount, cz / float ptCount)
+            let count = float ptCount // divide, just like Polyline3D.Center does, so the origin is the very same point
+            ox <- ox / count
+            oy <- oy / count
+            oz <- oz / count
 
             // Newell's method: sum up the cross products of all points around the center.
             // This averages out the noise of near planar points.
             // At the same time find the point that is furthest from the center, it spans the main axis.
-            let mutable newell = Vec.Zero
-            let mutable axis = Vec.Zero
-            let mutable axisLenSq = 0.0
-            let mutable a = (getPt (ptCount - 1) xyzs) - cen
-            for j = 0 to ptCount - 1 do
-                let b = (getPt j xyzs) - cen
-                newell <- newell + Vec.cross(a, b)
-                let lenSq = b.LengthSq
-                if lenSq > axisLenSq then
-                    axisLenSq <- lenSq
-                    axis <- b
-                a <- b
+            let mutable nx = 0.0
+            let mutable ny = 0.0
+            let mutable nz = 0.0
+            let mutable ux = 0.0 // the main axis
+            let mutable uy = 0.0
+            let mutable uz = 0.0
+            let mutable uLenSq = 0.0
+            let mutable ax = xyzs.[len - 3] - ox // the previous point, starting at the last one to close the loop
+            let mutable ay = xyzs.[len - 2] - oy
+            let mutable az = xyzs.[len - 1] - oz
+            i <- 0
+            while i < len do
+                let bx = xyzs.[i    ] - ox
+                let by = xyzs.[i + 1] - oy
+                let bz = xyzs.[i + 2] - oz
+                nx <- nx + ay * bz - az * by
+                ny <- ny + az * bx - ax * bz
+                nz <- nz + ax * by - ay * bx
+                let lenSq = XYZ.sqLength bx by bz
+                if lenSq > uLenSq then
+                    uLenSq <- lenSq
+                    ux <- bx
+                    uy <- by
+                    uz <- bz
+                ax <- bx
+                ay <- by
+                az <- bz
+                i <- i + 3
 
-            if axisLenSq <= tolerance * tolerance then
+            if uLenSq <= tolerance * tolerance then
                 ValueNone // all points are within the tolerance of the center point, so there is no unique plane
             else
                 // find the point that is furthest away from the main axis.
                 // The length of this cross product is the distance from the axis times the length of the axis.
-                let mutable perp = Vec.Zero
-                let mutable perpLenSq = 0.0
-                for j = 0 to ptCount - 1 do
-                    let v = Vec.cross(axis, (getPt j xyzs) - cen)
-                    let lenSq = v.LengthSq
-                    if lenSq > perpLenSq then
-                        perpLenSq <- lenSq
-                        perp <- v
-                if perpLenSq <= tolerance * tolerance * axisLenSq then
+                let mutable px = 0.0
+                let mutable py = 0.0
+                let mutable pz = 0.0
+                let mutable pLenSq = 0.0
+                i <- 0
+                while i < len do
+                    let vx = xyzs.[i    ] - ox
+                    let vy = xyzs.[i + 1] - oy
+                    let vz = xyzs.[i + 2] - oz
+                    let wx = uy * vz - uz * vy
+                    let wy = uz * vx - ux * vz
+                    let wz = ux * vy - uy * vx
+                    let lenSq = XYZ.sqLength wx wy wz
+                    if lenSq > pLenSq then
+                        pLenSq <- lenSq
+                        px <- wx
+                        py <- wy
+                        pz <- wz
+                    i <- i + 3
+
+                if pLenSq <= tolerance * tolerance * uLenSq then
                     ValueNone // all points are within the tolerance of one line, so there is no unique plane
                 else
                     // Newell's normal is preferred, it uses all points. But it cancels out to zero on
                     // self intersecting or very small shapes. Then the normal of the widest triangle is used.
-                    let normal =
-                        if isTooSmallSq newell.LengthSq then
-                            if Vec.dot(perp, newell) < 0.0 then -perp else perp // keep the orientation of the point order if there is any
+                    let mutable mx = nx
+                    let mutable my = ny
+                    let mutable mz = nz
+                    if isTooSmallSq (XYZ.sqLength nx ny nz) then
+                        if XYZ.dot px py pz nx ny nz < 0.0 then // keep the orientation of the point order if there is any
+                            mx <- -px
+                            my <- -py
+                            mz <- -pz
                         else
-                            newell
-                    let f = 1.0 / normal.Length
-                    let nx = normal.X * f
-                    let ny = normal.Y * f
-                    let nz = normal.Z * f
+                            mx <- px
+                            my <- py
+                            mz <- pz
+                    let f = 1.0 / XYZ.length mx my mz
+                    let normX = mx * f
+                    let normY = my * f
+                    let normZ = mz * f
                     // check that all points are within the tolerance of this plane
                     let mutable isPlanar = true
                     let mutable k = if checkPlanarity then 0 else len
                     while isPlanar && k < len do
-                        let d = (xyzs.[k] - cen.X) * nx + (xyzs.[k + 1] - cen.Y) * ny + (xyzs.[k + 2] - cen.Z) * nz
+                        let d = (xyzs.[k] - ox) * normX + (xyzs.[k + 1] - oy) * normY + (xyzs.[k + 2] - oz) * normZ
                         if abs d > tolerance then isPlanar <- false
                         k <- k + 3
                     if isPlanar then
-                        ValueSome (NPlane.createUnchecked(cen.X, cen.Y, cen.Z, nx, ny, nz))
+                        ValueSome (NPlane.createUnchecked(ox, oy, oz, normX, normY, normZ))
                     else
                         ValueNone
 
@@ -1164,14 +1202,29 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// Only an empty Polyline3D fails. Use TryAverageNormal to get None instead of a zero length vector.
     member pl.AverageNormal : Vec =
         let c = pl.Center // fails on empty Polyline3D
-        let mutable normal = Vec.Zero
-        let n = pl.PointCount
-        let mutable a = (getPt (n-1) xyzs) - c
-        for i = 0 to n-1 do
-            let b = (getPt i xyzs) - c
-            normal <- normal + Vec.cross(a, b)
-            a <- b
-        normal
+        let ox = c.X
+        let oy = c.Y
+        let oz = c.Z
+        let len = xyzs.Count
+        let mutable nx = 0.0
+        let mutable ny = 0.0
+        let mutable nz = 0.0
+        let mutable ax = xyzs.[len - 3] - ox // the previous point, starting at the last one to close the loop
+        let mutable ay = xyzs.[len - 2] - oy
+        let mutable az = xyzs.[len - 1] - oz
+        let mutable i = 0
+        while i < len do
+            let bx = xyzs.[i    ] - ox
+            let by = xyzs.[i + 1] - oy
+            let bz = xyzs.[i + 2] - oz
+            nx <- nx + ay * bz - az * by
+            ny <- ny + az * bx - ax * bz
+            nz <- nz + ax * by - ay * bx
+            ax <- bx
+            ay <- by
+            az <- bz
+            i <- i + 3
+        Vec(nx, ny, nz)
 
     /// Returns the average normal vector of the Polyline3D.
     /// It is calculated by summing up the cross products of all segments around the center point.

--- a/Src/Polyline3D.fs
+++ b/Src/Polyline3D.fs
@@ -35,6 +35,85 @@ module private Polyline3DUtil =
     let inline copy (xyzs: ResizeArray<float>) : ResizeArray<float> =
         xyzs.GetRange(0, xyzs.Count)
 
+    /// Tries to find the plane that all points lie in.
+    /// The 'tolerance' is the maximum distance any point may have from the plane.
+    /// The origin of the returned plane is the average of all points.
+    /// Returns ValueNone if there are less than 3 points,
+    /// if all points are within the tolerance of one point or of one line,
+    /// or if any point is further away from the plane than the tolerance.
+    let tryPlaneOf (tolerance:float) (xyzs: ResizeArray<float>) : NPlane voption =
+        let ptCount = countPts xyzs
+        if ptCount < 3 then
+            ValueNone
+        else
+            // the center of all points is the origin of the plane
+            let mutable cx = 0.0
+            let mutable cy = 0.0
+            let mutable cz = 0.0
+            let mutable i = 0
+            let len = xyzs.Count
+            while i < len do
+                cx <- cx + xyzs.[i]
+                cy <- cy + xyzs.[i + 1]
+                cz <- cz + xyzs.[i + 2]
+                i <- i + 3
+            let cen = Pnt(cx / float ptCount, cy / float ptCount, cz / float ptCount)
+
+            // Newell's method: sum up the cross products of all points around the center.
+            // This averages out the noise of near planar points.
+            // At the same time find the point that is furthest from the center, it spans the main axis.
+            let mutable newell = Vec.Zero
+            let mutable axis = Vec.Zero
+            let mutable axisLenSq = 0.0
+            let mutable a = (getPt (ptCount - 1) xyzs) - cen
+            for j = 0 to ptCount - 1 do
+                let b = (getPt j xyzs) - cen
+                newell <- newell + Vec.cross(a, b)
+                let lenSq = b.LengthSq
+                if lenSq > axisLenSq then
+                    axisLenSq <- lenSq
+                    axis <- b
+                a <- b
+
+            if axisLenSq <= tolerance * tolerance then
+                ValueNone // all points are within the tolerance of the center point, so there is no unique plane
+            else
+                // find the point that is furthest away from the main axis.
+                // The length of this cross product is the distance from the axis times the length of the axis.
+                let mutable perp = Vec.Zero
+                let mutable perpLenSq = 0.0
+                for j = 0 to ptCount - 1 do
+                    let v = Vec.cross(axis, (getPt j xyzs) - cen)
+                    let lenSq = v.LengthSq
+                    if lenSq > perpLenSq then
+                        perpLenSq <- lenSq
+                        perp <- v
+                if perpLenSq <= tolerance * tolerance * axisLenSq then
+                    ValueNone // all points are within the tolerance of one line, so there is no unique plane
+                else
+                    // Newell's normal is preferred, it uses all points. But it cancels out to zero on
+                    // self intersecting or very small shapes. Then the normal of the widest triangle is used.
+                    let normal =
+                        if isTooSmallSq newell.LengthSq then
+                            if Vec.dot(perp, newell) < 0.0 then -perp else perp // keep the orientation of the point order if there is any
+                        else
+                            newell
+                    let f = 1.0 / normal.Length
+                    let nx = normal.X * f
+                    let ny = normal.Y * f
+                    let nz = normal.Z * f
+                    // check that all points are within the tolerance of this plane
+                    let mutable isPlanar = true
+                    let mutable k = 0
+                    while isPlanar && k < len do
+                        let d = (xyzs.[k] - cen.X) * nx + (xyzs.[k + 1] - cen.Y) * ny + (xyzs.[k + 2] - cen.Z) * nz
+                        if abs d > tolerance then isPlanar <- false
+                        k <- k + 3
+                    if isPlanar then
+                        ValueSome (NPlane.createUnchecked(cen.X, cen.Y, cen.Z, nx, ny, nz))
+                    else
+                        ValueNone
+
 
 open Polyline3DUtil
 
@@ -1097,6 +1176,52 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// Does not check for bad input, may be zero length if points are collinear.
     static member inline averageNormal (pl:Polyline3D) : Vec =
         pl.AverageNormal
+
+    /// Tries to find the plane that all points of the Polyline3D lie in.
+    /// The optional 'tolerance' is the maximum distance any point may have from the plane, it defaults to 1e-6.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.Center.
+    /// The orientation of the normal follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// Returns None if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are within the tolerance of one point or of one line, so that there is no unique plane,
+    /// or any point is further away from the plane than the tolerance.
+    member _.TryPlane([<OPT;DEF(1e-6)>] tolerance:float) : NPlane option =
+        match tryPlaneOf tolerance xyzs with
+        | ValueSome pl -> Some pl
+        | ValueNone -> None
+
+    /// Tries to find the plane that all points of the Polyline3D lie in.
+    /// The 'tolerance' is the maximum distance any point may have from the plane. Use 1e-6 as a default.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.Center.
+    /// The orientation of the normal follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// Returns None if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are within the tolerance of one point or of one line, so that there is no unique plane,
+    /// or any point is further away from the plane than the tolerance.
+    static member inline tryPlane (tolerance:float) (pl:Polyline3D) : NPlane option =
+        pl.TryPlane(tolerance)
+
+    /// Tests if all points of the Polyline3D lie in one plane.
+    /// The optional 'tolerance' is the maximum distance any point may have from that plane, it defaults to 1e-6.
+    /// Returns FALSE if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line,
+    /// because then there is no unique plane.
+    member _.IsPlanar([<OPT;DEF(1e-6)>] tolerance:float) : bool =
+        match tryPlaneOf tolerance xyzs with
+        | ValueSome _ -> true
+        | ValueNone -> false
+
+    /// Tests if all points of the Polyline3D lie in one plane.
+    /// The 'tolerance' is the maximum distance any point may have from that plane. Use 1e-6 as a default.
+    /// Returns FALSE if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line,
+    /// because then there is no unique plane.
+    static member inline isPlanar (tolerance:float) (pl:Polyline3D) : bool =
+        pl.IsPlanar(tolerance)
 
     /// Scales the Polyline3D by a given factor.
     /// Scale center is World Origin 0,0,0

--- a/Src/Polyline3D.fs
+++ b/Src/Polyline3D.fs
@@ -35,6 +35,46 @@ module private Polyline3DUtil =
     let inline copy (xyzs: ResizeArray<float>) : ResizeArray<float> =
         xyzs.GetRange(0, xyzs.Count)
 
+    /// Sums up the cross products of all points around their center: Newell's method.
+    /// The result is not unitized, its length is twice the area of the polygon projected onto that plane.
+    /// Does not check for bad input, the result may be zero length, e.g. if all points are in one line.
+    /// There must be at least one point.
+    let averageNormalOf (xyzs: ResizeArray<float>) : Vec =
+        let len = xyzs.Count
+        // the center of all points
+        let mutable ox = 0.0
+        let mutable oy = 0.0
+        let mutable oz = 0.0
+        let mutable i = 0
+        while i < len do
+            ox <- ox + xyzs.[i    ]
+            oy <- oy + xyzs.[i + 1]
+            oz <- oz + xyzs.[i + 2]
+            i <- i + 3
+        let count = float (len / 3) // divide, just like Polyline3D.Center does, so the same center is used
+        ox <- ox / count
+        oy <- oy / count
+        oz <- oz / count
+        let mutable nx = 0.0
+        let mutable ny = 0.0
+        let mutable nz = 0.0
+        let mutable ax = xyzs.[len - 3] - ox // the previous point, starting at the last one to close the loop
+        let mutable ay = xyzs.[len - 2] - oy
+        let mutable az = xyzs.[len - 1] - oz
+        i <- 0
+        while i < len do
+            let bx = xyzs.[i    ] - ox
+            let by = xyzs.[i + 1] - oy
+            let bz = xyzs.[i + 2] - oz
+            nx <- nx + ay * bz - az * by
+            ny <- ny + az * bx - ax * bz
+            nz <- nz + ax * by - ay * bx
+            ax <- bx
+            ay <- by
+            az <- bz
+            i <- i + 3
+        Vec(nx, ny, nz)
+
     /// Tries to find the average plane of the points.
     /// If 'checkPlanarity' is TRUE it also verifies that every point is within the tolerance of that plane.
     /// The 'tolerance' is the maximum distance any point may have from the plane, and from one point or one line.
@@ -1198,44 +1238,37 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
 
     /// Returns the average normal vector of the Polyline3D.
     /// It is calculated by summing up the cross products of all segments around the center point.
-    /// Does not check for bad input, may be zero length if points are collinear.
-    /// Only an empty Polyline3D fails. Use TryAverageNormal to get None instead of a zero length vector.
+    /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
+    /// Fails if the summed normal is shorter than 1e-6, because then no normal can be found. This happens if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are in one line,
+    /// or the cross products cancel each other out on a self intersecting shape,
+    /// or the Polyline3D is very small.
+    /// Use TryAverageNormal to get None instead of an exception.
+    /// For the last two cases Polyline3D.AveragePlane still finds a plane.
     member pl.AverageNormal : Vec =
-        let c = pl.Center // fails on empty Polyline3D
-        let ox = c.X
-        let oy = c.Y
-        let oz = c.Z
-        let len = xyzs.Count
-        let mutable nx = 0.0
-        let mutable ny = 0.0
-        let mutable nz = 0.0
-        let mutable ax = xyzs.[len - 3] - ox // the previous point, starting at the last one to close the loop
-        let mutable ay = xyzs.[len - 2] - oy
-        let mutable az = xyzs.[len - 1] - oz
-        let mutable i = 0
-        while i < len do
-            let bx = xyzs.[i    ] - ox
-            let by = xyzs.[i + 1] - oy
-            let bz = xyzs.[i + 2] - oz
-            nx <- nx + ay * bz - az * by
-            ny <- ny + az * bx - ax * bz
-            nz <- nz + ax * by - ay * bx
-            ax <- bx
-            ay <- by
-            az <- bz
-            i <- i + 3
-        Vec(nx, ny, nz)
+        if pl.PointCount < 3 then failTooFewPoly3D "AverageNormal" 3 pl.PointCount
+        let n = averageNormalOf xyzs
+        if isTooSmallSq n.LengthSq then
+            fail $"Polyline3D.AverageNormal: no normal can be found. The points are in one line, or the cross products cancel each other out, or the Polyline3D is very small: {pl.AsString}"
+        n
 
     /// Returns the average normal vector of the Polyline3D.
     /// It is calculated by summing up the cross products of all segments around the center point.
-    /// Does not check for bad input, may be zero length if points are collinear.
-    /// Only an empty Polyline3D fails. Use tryAverageNormal to get None instead of a zero length vector.
+    /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
+    /// Fails if the summed normal is shorter than 1e-6, because then no normal can be found. This happens if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are in one line,
+    /// or the cross products cancel each other out on a self intersecting shape,
+    /// or the Polyline3D is very small.
+    /// Use tryAverageNormal to get None instead of an exception.
+    /// For the last two cases Polyline3D.averagePlane still finds a plane.
     static member inline averageNormal (pl:Polyline3D) : Vec =
         pl.AverageNormal
 
     /// Returns the average normal vector of the Polyline3D, or None if it is degenerate.
     /// It is calculated by summing up the cross products of all segments around the center point,
-    /// so it is the same vector as Polyline3D.AverageNormal, but bad input returns None instead of a zero length vector.
+    /// so it is the same vector as Polyline3D.AverageNormal, but bad input returns None instead of raising an exception.
     /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
     /// Returns None if the summed normal is shorter than 1e-6. This happens if:
     /// the Polyline3D has less than 3 points,
@@ -1247,13 +1280,13 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
         if pl.PointCount < 3 then
             None
         else
-            let n = pl.AverageNormal
+            let n = averageNormalOf xyzs
             if isTooSmallSq n.LengthSq then None
             else Some n
 
     /// Returns the average normal vector of the Polyline3D, or None if it is degenerate.
     /// It is calculated by summing up the cross products of all segments around the center point,
-    /// so it is the same vector as Polyline3D.averageNormal, but bad input returns None instead of a zero length vector.
+    /// so it is the same vector as Polyline3D.averageNormal, but bad input returns None instead of raising an exception.
     /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
     /// Returns None if the summed normal is shorter than 1e-6. This happens if:
     /// the Polyline3D has less than 3 points,
@@ -2509,7 +2542,7 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
                             ) : Polyline3D =
         if polyLine.PointCount < 2 then
             fail $"Polyline3D.offset: Polyline3D must have at least 2 points but has {polyLine.PointCount} points."
-        let refNormal = polyLine.AverageNormal
+        let refNormal = averageNormalOf polyLine.XYZs // not Polyline3D.AverageNormal, a degenerate normal is reported below
         if refNormal.LengthSq < 1e-8 then
             fail $"Polyline3D.offset: Cannot compute average normal of Polyline3D, the {polyLine.PointCount} points are collinear or too close together: {polyLine}"
         Polyline3D.offsetWithRef(polyLine, inPlaneOffsetDistance, perpendicularOffsetDistance, refNormal.Unitized, loop)
@@ -2627,7 +2660,7 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
                             ) : Polyline3D =
         if polyLine.PointCount < 2 then
             fail $"Polyline3D.offsetVar: Polyline3D must have at least 2 points but has {polyLine.PointCount} points."
-        let refNormal = polyLine.AverageNormal
+        let refNormal = averageNormalOf polyLine.XYZs // not Polyline3D.AverageNormal, a degenerate normal is reported below
         if refNormal.LengthSq < 1e-8 then
             fail $"Polyline3D.offsetVar: Cannot compute average normal of Polyline3D, the {polyLine.PointCount} points are collinear or too close together: {polyLine}"
         Polyline3D.offsetVarWithRef(polyLine, inPlaneOffsetDistances, perpendicularOffsetDistances, refNormal.Unitized, loop, varDistParallelBehavior, considerCollinearBelow, failAtUTurnAbove)

--- a/Src/Polyline3D.fs
+++ b/Src/Polyline3D.fs
@@ -35,13 +35,14 @@ module private Polyline3DUtil =
     let inline copy (xyzs: ResizeArray<float>) : ResizeArray<float> =
         xyzs.GetRange(0, xyzs.Count)
 
-    /// Tries to find the plane that all points lie in.
-    /// The 'tolerance' is the maximum distance any point may have from the plane.
+    /// Tries to find the average plane of the points.
+    /// If 'checkPlanarity' is TRUE it also verifies that every point is within the tolerance of that plane.
+    /// The 'tolerance' is the maximum distance any point may have from the plane, and from one point or one line.
     /// The origin of the returned plane is the average of all points.
     /// Returns ValueNone if there are less than 3 points,
     /// if all points are within the tolerance of one point or of one line,
-    /// or if any point is further away from the plane than the tolerance.
-    let tryPlaneOf (tolerance:float) (xyzs: ResizeArray<float>) : NPlane voption =
+    /// or, when checking planarity, if any point is further away from the plane than the tolerance.
+    let tryPlaneOf (checkPlanarity:bool) (tolerance:float) (xyzs: ResizeArray<float>) : NPlane voption =
         let ptCount = countPts xyzs
         if ptCount < 3 then
             ValueNone
@@ -104,7 +105,7 @@ module private Polyline3DUtil =
                     let nz = normal.Z * f
                     // check that all points are within the tolerance of this plane
                     let mutable isPlanar = true
-                    let mutable k = 0
+                    let mutable k = if checkPlanarity then 0 else len
                     while isPlanar && k < len do
                         let d = (xyzs.[k] - cen.X) * nx + (xyzs.[k + 1] - cen.Y) * ny + (xyzs.[k + 2] - cen.Z) * nz
                         if abs d > tolerance then isPlanar <- false
@@ -1160,6 +1161,7 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// Returns the average normal vector of the Polyline3D.
     /// It is calculated by summing up the cross products of all segments around the center point.
     /// Does not check for bad input, may be zero length if points are collinear.
+    /// Only an empty Polyline3D fails. Use TryAverageNormal to get None instead of a zero length vector.
     member pl.AverageNormal : Vec =
         let c = pl.Center // fails on empty Polyline3D
         let mutable normal = Vec.Zero
@@ -1174,8 +1176,98 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// Returns the average normal vector of the Polyline3D.
     /// It is calculated by summing up the cross products of all segments around the center point.
     /// Does not check for bad input, may be zero length if points are collinear.
+    /// Only an empty Polyline3D fails. Use tryAverageNormal to get None instead of a zero length vector.
     static member inline averageNormal (pl:Polyline3D) : Vec =
         pl.AverageNormal
+
+    /// Returns the average normal vector of the Polyline3D, or None if it is degenerate.
+    /// It is calculated by summing up the cross products of all segments around the center point,
+    /// so it is the same vector as Polyline3D.AverageNormal, but bad input returns None instead of a zero length vector.
+    /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
+    /// Returns None if the summed normal is shorter than 1e-6. This happens if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are in one line,
+    /// or the cross products cancel each other out on a self intersecting shape,
+    /// or the Polyline3D is very small.
+    /// For these last two cases Polyline3D.TryAveragePlane still finds a plane.
+    member pl.TryAverageNormal : Vec option =
+        if pl.PointCount < 3 then
+            None
+        else
+            let n = pl.AverageNormal
+            if isTooSmallSq n.LengthSq then None
+            else Some n
+
+    /// Returns the average normal vector of the Polyline3D, or None if it is degenerate.
+    /// It is calculated by summing up the cross products of all segments around the center point,
+    /// so it is the same vector as Polyline3D.averageNormal, but bad input returns None instead of a zero length vector.
+    /// The returned vector is not unitized, its length is twice the area of the polygon projected onto that plane.
+    /// Returns None if the summed normal is shorter than 1e-6. This happens if:
+    /// the Polyline3D has less than 3 points,
+    /// or all points are in one line,
+    /// or the cross products cancel each other out on a self intersecting shape,
+    /// or the Polyline3D is very small.
+    /// For these last two cases Polyline3D.tryAveragePlane still finds a plane.
+    static member inline tryAverageNormal (pl:Polyline3D) : Vec option =
+        pl.TryAverageNormal
+
+    /// Returns the average plane of the Polyline3D, even if the points are not planar.
+    /// As opposed to Polyline3D.TryPlane this does not check if all points are on that plane.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.Center.
+    /// The normal is the unitized Polyline3D.AverageNormal, so it follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// The optional 'tolerance' is the maximum distance for considering all points to be on one point or on one line,
+    /// it defaults to 1e-6.
+    /// Fails if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line, because then there is no unique plane.
+    member p.AveragePlane([<OPT;DEF(1e-6)>] tolerance:float) : NPlane =
+        match tryPlaneOf false tolerance xyzs with
+        | ValueSome pln -> pln
+        | ValueNone ->
+            if p.PointCount < 3 then failTooFewPoly3D "AveragePlane" 3 p.PointCount
+            else fail $"Polyline3D.AveragePlane: all points are within the tolerance of {tolerance} of one point or of one line, so there is no unique plane: {p.AsString}"
+
+    /// Returns the average plane of the Polyline3D, even if the points are not planar.
+    /// As opposed to Polyline3D.tryPlane this does not check if all points are on that plane.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.center.
+    /// The normal is the unitized Polyline3D.averageNormal, so it follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// The 'tolerance' is the maximum distance for considering all points to be on one point or on one line.
+    /// Use 1e-6 as a default.
+    /// Fails if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line, because then there is no unique plane.
+    static member inline averagePlane (tolerance:float) (pl:Polyline3D) : NPlane =
+        pl.AveragePlane(tolerance)
+
+    /// Tries to find the average plane of the Polyline3D, even if the points are not planar.
+    /// As opposed to Polyline3D.TryPlane this does not check if all points are on that plane.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.Center.
+    /// The normal is the unitized Polyline3D.AverageNormal, so it follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// The optional 'tolerance' is the maximum distance for considering all points to be on one point or on one line,
+    /// it defaults to 1e-6.
+    /// Returns None if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line, because then there is no unique plane.
+    member _.TryAveragePlane([<OPT;DEF(1e-6)>] tolerance:float) : NPlane option =
+        match tryPlaneOf false tolerance xyzs with
+        | ValueSome pln -> Some pln
+        | ValueNone -> None
+
+    /// Tries to find the average plane of the Polyline3D, even if the points are not planar.
+    /// As opposed to Polyline3D.tryPlane this does not check if all points are on that plane.
+    /// The origin of the returned NPlane is the average of all points, see Polyline3D.center.
+    /// The normal is the unitized Polyline3D.averageNormal, so it follows the order of the points.
+    /// If they are counter-clockwise in the World X-Y plane, then the normal points in World Z direction.
+    /// On self intersecting shapes, where these cross products cancel each other out, the orientation is arbitrary.
+    /// The 'tolerance' is the maximum distance for considering all points to be on one point or on one line.
+    /// Use 1e-6 as a default.
+    /// Returns None if the Polyline3D has less than 3 points,
+    /// or if all points are within the tolerance of one point or of one line, because then there is no unique plane.
+    static member inline tryAveragePlane (tolerance:float) (pl:Polyline3D) : NPlane option =
+        pl.TryAveragePlane(tolerance)
 
     /// Tries to find the plane that all points of the Polyline3D lie in.
     /// The optional 'tolerance' is the maximum distance any point may have from the plane, it defaults to 1e-6.
@@ -1187,8 +1279,9 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// the Polyline3D has less than 3 points,
     /// or all points are within the tolerance of one point or of one line, so that there is no unique plane,
     /// or any point is further away from the plane than the tolerance.
+    /// Use Polyline3D.TryAveragePlane to get the average plane of non planar points too.
     member _.TryPlane([<OPT;DEF(1e-6)>] tolerance:float) : NPlane option =
-        match tryPlaneOf tolerance xyzs with
+        match tryPlaneOf true tolerance xyzs with
         | ValueSome pl -> Some pl
         | ValueNone -> None
 
@@ -1202,6 +1295,7 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// the Polyline3D has less than 3 points,
     /// or all points are within the tolerance of one point or of one line, so that there is no unique plane,
     /// or any point is further away from the plane than the tolerance.
+    /// Use Polyline3D.tryAveragePlane to get the average plane of non planar points too.
     static member inline tryPlane (tolerance:float) (pl:Polyline3D) : NPlane option =
         pl.TryPlane(tolerance)
 
@@ -1211,7 +1305,7 @@ type Polyline3D private (xyzs: ResizeArray<float>) =
     /// or if all points are within the tolerance of one point or of one line,
     /// because then there is no unique plane.
     member _.IsPlanar([<OPT;DEF(1e-6)>] tolerance:float) : bool =
-        match tryPlaneOf tolerance xyzs with
+        match tryPlaneOf true tolerance xyzs with
         | ValueSome _ -> true
         | ValueNone -> false
 

--- a/Test/TestPolyline3D.fs
+++ b/Test/TestPolyline3D.fs
@@ -882,4 +882,108 @@ let tests =
                 Expect.equal cleaned.PointCount 1 "single point returned as is"
             }
         ]
+
+        testList "TryPlane and IsPlanar" [
+            test "counterclockwise square in XY plane" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.); Pnt(1.,1.,0.); Pnt(0.,1.,0.); Pnt(0.,0.,0.)]
+                "square is planar" |> Expect.isTrue (pl.IsPlanar())
+                match pl.TryPlane() with
+                | Some pln ->
+                    "normal points up for a CCW square in the XY plane" |> Expect.floatClose tol pln.Normal.Z 1.0
+                    "origin is the average of all points" |> Expect.isTrue (eqPnt pln.Origin pl.Center)
+                    "origin is on the XY plane" |> Expect.floatClose tol pln.Origin.Z 0.0
+                | None ->
+                    "square has a plane" |> Expect.isTrue false
+            }
+
+            test "clockwise square has a flipped normal" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(0.,1.,0.); Pnt(1.,1.,0.); Pnt(1.,0.,0.)]
+                match pl.TryPlane() with
+                | Some pln -> "normal points down for a CW square in the XY plane" |> Expect.floatClose tol pln.Normal.Z -1.0
+                | None -> "square has a plane" |> Expect.isTrue false
+            }
+
+            test "triangle in a tilted plane" {
+                let a = Pnt(1.,2.,3.)
+                let b = Pnt(4.,2.,3.)
+                let c = Pnt(1.,5.,7.)
+                let pl = Polyline3D.createFromPts [a; b; c]
+                let expected = (NPlane.createFrom3Points a b c).Normal
+                match pl.TryPlane() with
+                | Some pln ->
+                    "normal matches the plane through the three points" |> Expect.floatClose tol (UnitVec.dot(pln.Normal, expected)) 1.0
+                    "all points are on the plane" |> Expect.isTrue (pl.AsPoints |> Seq.forall (fun p -> abs (NPlane.distanceToPntSigned p pln) < 1e-9))
+                | None -> "triangle has a plane" |> Expect.isTrue false
+            }
+
+            test "non planar polyline returns None" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.); Pnt(1.,1.,1.); Pnt(0.,1.,0.)]
+                "warped quad is not planar" |> Expect.isFalse (pl.IsPlanar())
+                "warped quad has no plane" |> Expect.isTrue (pl.TryPlane() |> Option.isNone)
+            }
+
+            test "tolerance decides on an almost planar polyline" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.); Pnt(1.,1.,0.001); Pnt(0.,1.,0.)]
+                "not planar within the default tolerance" |> Expect.isFalse (pl.IsPlanar())
+                "planar within a 0.01 tolerance" |> Expect.isTrue (pl.IsPlanar(0.01))
+                "static isPlanar is curried" |> Expect.isTrue (Polyline3D.isPlanar 0.01 pl)
+                "static tryPlane is curried" |> Expect.isTrue (Polyline3D.tryPlane 0.01 pl |> Option.isSome)
+                "static tryPlane with a tight tolerance" |> Expect.isTrue (Polyline3D.tryPlane 1e-6 pl |> Option.isNone)
+            }
+
+            test "less than three points has no plane" {
+                "empty polyline" |> Expect.isFalse ((Polyline3D([])).IsPlanar())
+                "one point" |> Expect.isFalse ((Polyline3D.createFromPts [Pnt(1.,2.,3.)]).IsPlanar())
+                "two points" |> Expect.isFalse ((Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.)]).IsPlanar())
+                "two points have no plane" |> Expect.isTrue ((Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.)]).TryPlane() |> Option.isNone)
+            }
+
+            test "collinear points have no unique plane" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.); Pnt(3.,3.,3.)]
+                "collinear points are not planar" |> Expect.isFalse (pl.IsPlanar())
+                "collinear points have no plane" |> Expect.isTrue (pl.TryPlane() |> Option.isNone)
+            }
+
+            test "almost collinear points still define a plane" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.001,0.); Pnt(2.,0.,0.)]
+                "the tiny offset is bigger than the tolerance" |> Expect.isTrue (pl.IsPlanar())
+                "within a 0.01 tolerance the points are on one line" |> Expect.isFalse (pl.IsPlanar(0.01))
+            }
+
+            test "duplicate points have no unique plane" {
+                let pl = Polyline3D.createFromPts [Pnt(5.,5.,5.); Pnt(5.,5.,5.); Pnt(5.,5.,5.); Pnt(5.,5.,5.)]
+                "coincident points are not planar" |> Expect.isFalse (pl.IsPlanar())
+                "coincident points have no plane" |> Expect.isTrue (pl.TryPlane() |> Option.isNone)
+            }
+
+            test "self intersecting planar polyline still finds the plane" {
+                // a bow tie, the summed cross products of Newell's method cancel out to zero here
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,4.); Pnt(1.,0.,4.); Pnt(0.,1.,4.); Pnt(1.,1.,4.); Pnt(0.,0.,4.)]
+                "bow tie is planar" |> Expect.isTrue (pl.IsPlanar())
+                match pl.TryPlane() with
+                | Some pln ->
+                    "normal is vertical" |> Expect.floatClose tol (abs pln.Normal.Z) 1.0
+                    "plane is at z=4" |> Expect.floatClose tol pln.Origin.Z 4.0
+                | None -> "bow tie has a plane" |> Expect.isTrue false
+            }
+
+            test "very small polyline is still planar" {
+                // the summed normal of Newell's method is shorter than 1e-6 here
+                let s = 1e-4
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(s,0.,0.); Pnt(s,s,0.); Pnt(0.,s,0.)]
+                "tiny square is planar" |> Expect.isTrue (pl.IsPlanar(1e-12))
+                match pl.TryPlane(1e-12) with
+                | Some pln -> "normal points up for a CCW tiny square" |> Expect.floatClose tol pln.Normal.Z 1.0
+                | None -> "tiny square has a plane" |> Expect.isTrue false
+            }
+
+            test "polyline in a plane parallel to the world XZ plane" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,7.,0.); Pnt(1.,7.,0.); Pnt(1.,7.,1.); Pnt(0.,7.,1.)]
+                match pl.TryPlane() with
+                | Some pln ->
+                    "normal is along Y" |> Expect.floatClose tol (abs pln.Normal.Y) 1.0
+                    "origin y is 7" |> Expect.floatClose tol pln.Origin.Y 7.0
+                | None -> "vertical square has a plane" |> Expect.isTrue false
+            }
+        ]
     ]

--- a/Test/TestPolyline3D.fs
+++ b/Test/TestPolyline3D.fs
@@ -979,10 +979,16 @@ let tests =
                 | None -> "tiny square has a plane" |> Expect.isTrue false
             }
 
-            test "AverageNormal does not throw on collinear points, it returns a zero vector" {
-                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.)]
-                "collinear points give a zero length average normal" |> Expect.floatClose tol pl.AverageNormal.Length 0.0
-                "AverageNormal throws only on an empty polyline" |> Expect.throws (fun () -> (Polyline3D([])).AverageNormal |> ignore)
+            test "AverageNormal fails when no normal can be found" {
+                let collinear = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.)]
+                "collinear points have no average normal" |> Expect.throws (fun () -> collinear.AverageNormal |> ignore)
+                "empty polyline" |> Expect.throws (fun () -> (Polyline3D([])).AverageNormal |> ignore)
+                "two points" |> Expect.throws (fun () -> (Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.)]).AverageNormal |> ignore)
+                "coincident points" |> Expect.throws (fun () -> (Polyline3D.createFromPts [Pnt(5.,5.,5.); Pnt(5.,5.,5.); Pnt(5.,5.,5.)]).AverageNormal |> ignore)
+                let bowTie = Polyline3D.createFromPts [Pnt(0.,0.,4.); Pnt(1.,0.,4.); Pnt(0.,1.,4.); Pnt(1.,1.,4.)]
+                "the cross products cancel out on a bow tie" |> Expect.throws (fun () -> bowTie.AverageNormal |> ignore)
+                "but AveragePlane still finds the plane" |> Expect.floatClose tol (abs (bowTie.AveragePlane()).Normal.Z) 1.0
+                "static averageNormal fails too" |> Expect.throws (fun () -> Polyline3D.averageNormal collinear |> ignore)
             }
 
             test "TryAverageNormal returns the same vector as AverageNormal" {

--- a/Test/TestPolyline3D.fs
+++ b/Test/TestPolyline3D.fs
@@ -10,6 +10,8 @@ open Expecto
 
 let inline eqPnt a b = Pnt.dist a b < 1e-9
 
+let inline eqVec a b = Vec.length (a - b) < 1e-9
+
 let tol = Accuracy.veryHigh
 
 let tests =
@@ -975,6 +977,62 @@ let tests =
                 match pl.TryPlane(1e-12) with
                 | Some pln -> "normal points up for a CCW tiny square" |> Expect.floatClose tol pln.Normal.Z 1.0
                 | None -> "tiny square has a plane" |> Expect.isTrue false
+            }
+
+            test "AverageNormal does not throw on collinear points, it returns a zero vector" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.)]
+                "collinear points give a zero length average normal" |> Expect.floatClose tol pl.AverageNormal.Length 0.0
+                "AverageNormal throws only on an empty polyline" |> Expect.throws (fun () -> (Polyline3D([])).AverageNormal |> ignore)
+            }
+
+            test "TryAverageNormal returns the same vector as AverageNormal" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.); Pnt(1.,1.,0.); Pnt(0.,1.,0.)]
+                match pl.TryAverageNormal with
+                | Some n ->
+                    "same vector as AverageNormal" |> Expect.isTrue (eqVec n pl.AverageNormal)
+                    "not unitized, its length is twice the area" |> Expect.floatClose tol n.Length 2.0
+                | None -> "square has an average normal" |> Expect.isTrue false
+                "static tryAverageNormal" |> Expect.isTrue (Polyline3D.tryAverageNormal pl |> Option.isSome)
+            }
+
+            test "TryAverageNormal returns None on degenerate input" {
+                let collinear = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.)]
+                "collinear points" |> Expect.isTrue (collinear.TryAverageNormal |> Option.isNone)
+                "empty polyline" |> Expect.isTrue ((Polyline3D([])).TryAverageNormal |> Option.isNone)
+                "two points" |> Expect.isTrue ((Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.)]).TryAverageNormal |> Option.isNone)
+                let bowTie = Polyline3D.createFromPts [Pnt(0.,0.,4.); Pnt(1.,0.,4.); Pnt(0.,1.,4.); Pnt(1.,1.,4.)]
+                "the cross products cancel out on a bow tie" |> Expect.isTrue (bowTie.TryAverageNormal |> Option.isNone)
+                "but TryAveragePlane still finds the plane" |> Expect.isTrue (bowTie.TryAveragePlane() |> Option.isSome)
+            }
+
+            test "AveragePlane works on non planar points" {
+                let pl = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.); Pnt(1.,1.,1.); Pnt(0.,1.,0.)]
+                "the warped quad is not planar" |> Expect.isFalse (pl.IsPlanar())
+                "so TryPlane finds nothing" |> Expect.isTrue (pl.TryPlane() |> Option.isNone)
+                "but there is an average plane" |> Expect.isTrue (pl.TryAveragePlane() |> Option.isSome)
+                let pln = pl.AveragePlane()
+                "origin is the average of all points" |> Expect.isTrue (eqPnt pln.Origin pl.Center)
+                "normal points up" |> Expect.isTrue (pln.Normal.Z > 0.0)
+                "normal is the unitized AverageNormal" |> Expect.floatClose tol (UnitVec.dot(pln.Normal, pl.AverageNormal.Unitized)) 1.0
+                "static averagePlane is curried" |> Expect.isTrue (eqPnt (Polyline3D.averagePlane 1e-6 pl).Origin pln.Origin)
+                "static tryAveragePlane is curried" |> Expect.isTrue (Polyline3D.tryAveragePlane 1e-6 pl |> Option.isSome)
+            }
+
+            test "AveragePlane of a planar polyline matches TryPlane" {
+                let pl = Polyline3D.createFromPts [Pnt(1.,2.,3.); Pnt(4.,2.,3.); Pnt(4.,5.,7.); Pnt(1.,5.,7.)]
+                match pl.TryPlane(), pl.TryAveragePlane() with
+                | Some strict, Some avg ->
+                    "same origin" |> Expect.isTrue (eqPnt strict.Origin avg.Origin)
+                    "same normal" |> Expect.floatClose tol (UnitVec.dot(strict.Normal, avg.Normal)) 1.0
+                | _ -> "planar polyline has both planes" |> Expect.isTrue false
+            }
+
+            test "AveragePlane fails on degenerate input" {
+                let collinear = Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,1.,1.); Pnt(2.,2.,2.)]
+                "collinear points have no average plane" |> Expect.isTrue (collinear.TryAveragePlane() |> Option.isNone)
+                "AveragePlane throws on collinear points" |> Expect.throws (fun () -> collinear.AveragePlane() |> ignore)
+                "AveragePlane throws on too few points" |> Expect.throws (fun () -> (Polyline3D.createFromPts [Pnt(0.,0.,0.); Pnt(1.,0.,0.)]).AveragePlane() |> ignore)
+                "AveragePlane throws on coincident points" |> Expect.throws (fun () -> (Polyline3D.createFromPts [Pnt(5.,5.,5.); Pnt(5.,5.,5.); Pnt(5.,5.,5.)]).AveragePlane() |> ignore)
             }
 
             test "polyline in a plane parallel to the world XZ plane" {


### PR DESCRIPTION
Adds the plane detection for planar 3D polylines:

- TryPlane / tryPlane returns the NPlane a planar Polyline3D lies in, or None.
- IsPlanar / isPlanar tests the same without returning the plane.

Both take an optional distance tolerance that defaults to 1e-6.
The plane origin is the average of all points, the normal follows the
order of the points (counter-clockwise in the World X-Y plane gives a
normal in World Z direction).

The normal is found with Newell's method so noise of near planar points
averages out. On self intersecting or very small shapes, where the summed
cross products cancel out, the normal of the widest triangle spanned by
the points is used instead. Degenerate input returns None: less than 3
points, or all points within the tolerance of one point or of one line,
because there is no unique plane then.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WMUgVw6EaCyo3iCoYZDc3z