### PR TITLE
Add pointAtDistanceFromEnd to Line2D and Line3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added `Line2D.pointAtDistanceFromEnd` and `Line3D.pointAtDistanceFromEnd`, finding a point at a given distance from the line end, going towards the start.
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
 - Added `Polyline3D.TryPlane` and `Polyline3D.IsPlanar`, plus the static `tryPlane` and `isPlanar`, to get the `NPlane` of a planar Polyline3D within a tolerance.
 - Added `Polyline3D.AveragePlane` and `Polyline3D.TryAveragePlane`, plus the static `averagePlane` and `tryAveragePlane`, to get the average `NPlane` of a Polyline3D even when its points are not planar.

--- a/Src/TypeExtensions/Line2D.fs
+++ b/Src/TypeExtensions/Line2D.fs
@@ -1517,6 +1517,16 @@ module AutoOpenLine2D =
         Pt(ln.FromX + x*dist/len,
             ln.FromY + y*dist/len)
 
+    /// Finds point at given distance from line end, going towards start.
+    /// Fails on lines shorter than UtilEuclid.zeroLengthTolerance (1e-12).
+    static member inline pointAtDistanceFromEnd dist (ln:Line2D) : Pt =
+        let x = ln.VectorX
+        let y = ln.VectorY
+        let len = sqrt(x*x + y*y)
+        if isTooTiny len then failTooSmall "Line2D.pointAtDistanceFromEnd" ln
+        Pt(ln.ToX - x*dist/len,
+            ln.ToY - y*dist/len)
+
     /// Returns new Line2D with given length, going out from start in direction of end.
     /// Fails on lines shorter than UtilEuclid.zeroLengthTolerance (1e-12).
     static member inline withLengthFromStart len (ln:Line2D) : Line2D =

--- a/Src/TypeExtensions/Line3D.fs
+++ b/Src/TypeExtensions/Line3D.fs
@@ -1849,6 +1849,19 @@ module AutoOpenLine3D =
             ln.FromY + y*f,
             ln.FromZ + z*f)
 
+    /// Finds point at given distance from line end, going towards start.
+    /// Fails on lines shorter than UtilEuclid.zeroLengthTolerance (1e-12).
+    static member inline pointAtDistanceFromEnd dist (ln:Line3D) : Pnt =
+        let x = ln.VectorX
+        let y = ln.VectorY
+        let z = ln.VectorZ
+        let len = XYZ.length x y z
+        if isTooTiny len then failTooSmall "Line3D.pointAtDistanceFromEnd" ln
+        let f = dist/len
+        Pnt(ln.ToX - x*f,
+            ln.ToY - y*f,
+            ln.ToZ - z*f)
+
     /// Returns new Line3D with given length, going out from start in direction of end.
     /// Fails on lines shorter than UtilEuclid.zeroLengthTolerance (1e-12).
     static member inline withLengthFromStart len (ln:Line3D) : Line3D =

--- a/Test/TestAPI.fs
+++ b/Test/TestAPI.fs
@@ -1115,6 +1115,7 @@ module Line2DAPI =
     let (_:Line2D) = Line2D.shrinkStart 1.0 line2d
     let (_:Line2D) = Line2D.shrinkEnd 1.0 line2d
     let (_:Pt) = Line2D.pointAtDistance 5.0 line2d
+    let (_:Pt) = Line2D.pointAtDistanceFromEnd 5.0 line2d
     let (_:Line2D) = Line2D.withLengthFromStart 5.0 line2d
     let (_:Line2D) = Line2D.withLengthToEnd 5.0 line2d
     let (_:Line2D) = Line2D.withLengthFromMid 5.0 line2d

--- a/Test/TestLine.fs
+++ b/Test/TestLine.fs
@@ -1557,6 +1557,35 @@ let testsLine2DWithLength =
             let ln = Line2D(0., 0., 1e-13, 0.)
             "too short throws" |> Expect.throws (fun () -> Line2D.pointAtDistance 1. ln |> ignore)
         }
+
+        test "pointAtDistanceFromEnd positive" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let pt = Line2D.pointAtDistanceFromEnd 3. ln
+            "point at distance 3 from end" |> expectEqualEpsilon pt.X 7.
+        }
+
+        test "pointAtDistanceFromEnd negative" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let pt = Line2D.pointAtDistanceFromEnd -2. ln
+            "negative goes beyond end" |> expectEqualEpsilon pt.X 12.
+        }
+
+        test "pointAtDistanceFromEnd beyond start" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let pt = Line2D.pointAtDistanceFromEnd 15. ln
+            "extends beyond start" |> expectEqualEpsilon pt.X -5.
+        }
+
+        test "pointAtDistanceFromEnd diagonal" {
+            let ln = Line2D(0., 0., 3., 4.)
+            let pt = Line2D.pointAtDistanceFromEnd 5. ln
+            "at line start for 3-4-5 triangle" |> Expect.isTrue (eq pt ln.From)
+        }
+
+        test "pointAtDistanceFromEnd too short line throws" {
+            let ln = Line2D(0., 0., 1e-13, 0.)
+            "too short throws" |> Expect.throws (fun () -> Line2D.pointAtDistanceFromEnd 1. ln |> ignore)
+        }
     ]
 
 
@@ -2636,6 +2665,35 @@ let testsLine3DWithLength =
         test "pointAtDistance too short line throws" {
             let ln = Line3D(0., 0., 0., 1e-13, 0., 0.)
             "too short throws" |> Expect.throws (fun () -> Line3D.pointAtDistance 3. ln |> ignore)
+        }
+
+        test "pointAtDistanceFromEnd positive" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let pt = Line3D.pointAtDistanceFromEnd 3. ln
+            "point at distance 3 from end" |> expectEqualEpsilon pt.X 7.
+        }
+
+        test "pointAtDistanceFromEnd negative" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let pt = Line3D.pointAtDistanceFromEnd -3. ln
+            "negative goes beyond end" |> expectEqualEpsilon pt.X 13.
+        }
+
+        test "pointAtDistanceFromEnd beyond start" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let pt = Line3D.pointAtDistanceFromEnd 15. ln
+            "point beyond start" |> expectEqualEpsilon pt.X -5.
+        }
+
+        test "pointAtDistanceFromEnd diagonal" {
+            let ln = Line3D(0., 0., 0., 10., 10., 10.)
+            let pt = Line3D.pointAtDistanceFromEnd (ln.Length / 2.) ln
+            "midpoint" |> Expect.isTrue (Pnt.dist pt ln.Mid < 1e-9)
+        }
+
+        test "pointAtDistanceFromEnd too short line throws" {
+            let ln = Line3D(0., 0., 0., 1e-13, 0., 0.)
+            "too short throws" |> Expect.throws (fun () -> Line3D.pointAtDistanceFromEnd 3. ln |> ignore)
         }
     ]
 


### PR DESCRIPTION
Mirrors pointAtDistance but measures from the line end towards the
start, for symmetry with withLengthFromStart/withLengthToEnd.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dvkyzq1GCibiTswAg3LDJe