### PR TITLE
Deprecate translate(vector) alias for local-axis types, clarify MoveX/Y/Z docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Polyline3D.TryAverageNormal` and the static `tryAverageNormal`, returning `None` instead of failing where `AverageNormal` finds no normal.
 - The unsafe internal constructors of `NPlane`, `PPlane`, `Box`, `BRect`, and `BBox`, and therefore all their `createUnchecked` members, now verify their input when compiled in DEBUG mode or with the `CHECKED_EUCLID` symbol defined. This covers unitized normals and axes, perpendicular and right-handed frames, `NaN` and `Infinity` values, and min values not being bigger than max values. The other unsafe constructors already did this.
 - Documented the `CHECKED_EUCLID` compiler flag in the Readme.
+- Added `Rect3D.translateLocalZ`, an alias of `Rect3D.offsetZ`, for naming consistency with `Box.translateLocalX/Y/Z` and `Rect3D.translateLocalX/Y`.
 
 ### Changed
 - `Polyline3D.AverageNormal` now fails if no normal can be found, instead of silently returning an almost zero length vector. This is the case if the Polyline3D has less than 3 points, if all points are in one line, if the cross products cancel each other out on a self intersecting shape, or if the Polyline3D is very small. Use `Polyline3D.TryAverageNormal` to get `None` instead of an exception.
 - The `CHECK_EUCLID` compiler symbol was renamed to `CHECKED_EUCLID`.
 - Pinned the `System.Text.Json` package reference (net472 only) to the lowest version providing the required APIs, `4.6.0`, instead of tracking latest, and excluded it from Dependabot version updates.
+- Clarified the docstrings of `Box.MoveX/Y/Z`, `Rect2D.MoveX/Y`, and `Rect3D.MoveX/Y/Z` (instance and static) to state that they move along the **world** X/Y/Z axes, not the shape's own (possibly rotated) local axes. Use `translateLocalX/Y/Z` for local-axis moves.
+
+### Deprecated
+- `Box.translate`, `Rect2D.translate`, `Rect3D.translate`, and `PPlane.translate` are obsolete. They were plain aliases for `.move` (a world-space vector translation), which is ambiguous alongside the local-axis `translateLocalX/Y/Z` members on the same types. Use `.move` (or `PPlane.translateBy`) for a world-space vector, or `.translateLocalX/Y/Z` to move along the shape's own axes.
 
 ## [0.51.0] - 2026-07-28
 ### Added

--- a/Src/Box.fs
+++ b/Src/Box.fs
@@ -532,35 +532,41 @@ type Box =
     static member inline scaleOn (cen:Pnt) (factor:float) (b:Box) : Box =
         b.ScaleOn cen factor
 
-    /// Returns a 3D box moved by a vector. Same as Box.translate.
+    /// Returns a 3D box moved by a vector in world space. The box's axes are unchanged.
     member inline b.Move (v:Vec) : Box =
         Box.createUnchecked(b.OriginX + v.X, b.OriginY + v.Y, b.OriginZ + v.Z, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Creates a 3D box moved by a vector. Same as Box.translate.
+    /// Creates a 3D box moved by a vector in world space. The box's axes are unchanged.
     static member inline move (v:Vec) (b:Box)  : Box =
         Box.createUnchecked(b.OriginX + v.X, b.OriginY + v.Y, b.OriginZ + v.Z, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns a 3D box moved by a given distance in X direction.
+    /// Returns a 3D box moved by a given distance along the world X-axis.
+    /// This is not the box's own (possibly rotated) local X-axis, use Box.translateLocalX for that.
     member inline b.MoveX (distance:float) : Box =
         Box.createUnchecked(b.OriginX + distance, b.OriginY, b.OriginZ, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns the 3D box moved by a given distance in X direction.
+    /// Returns the 3D box moved by a given distance along the world X-axis.
+    /// This is not the box's own (possibly rotated) local X-axis, use Box.translateLocalX for that.
     static member inline moveX (distance:float) (b:Box) : Box =
         Box.createUnchecked(b.OriginX + distance, b.OriginY, b.OriginZ, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns a 3D box moved by a given distance in Y direction.
+    /// Returns a 3D box moved by a given distance along the world Y-axis.
+    /// This is not the box's own (possibly rotated) local Y-axis, use Box.translateLocalY for that.
     member inline b.MoveY (distance:float) : Box =
         Box.createUnchecked(b.OriginX, b.OriginY + distance, b.OriginZ, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns the 3D box moved by a given distance in Y direction.
+    /// Returns the 3D box moved by a given distance along the world Y-axis.
+    /// This is not the box's own (possibly rotated) local Y-axis, use Box.translateLocalY for that.
     static member inline moveY (distance:float) (b:Box) : Box =
         Box.createUnchecked(b.OriginX, b.OriginY + distance, b.OriginZ, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns a 3D box moved by a given distance in Z direction.
+    /// Returns a 3D box moved by a given distance along the world Z-axis.
+    /// This is not the box's own (possibly rotated) local Z-axis, use Box.translateLocalZ for that.
     member inline b.MoveZ (distance:float) : Box =
         Box.createUnchecked(b.OriginX, b.OriginY, b.OriginZ + distance, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
-    /// Returns the 3D box moved by a given distance in Z direction.
+    /// Returns the 3D box moved by a given distance along the world Z-axis.
+    /// This is not the box's own (possibly rotated) local Z-axis, use Box.translateLocalZ for that.
     static member inline moveZ (distance:float) (b:Box) : Box =
         Box.createUnchecked(b.OriginX, b.OriginY, b.OriginZ + distance, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
@@ -1022,6 +1028,7 @@ type Box =
         Box.createUnchecked(b.OriginX + b.ZaxisX*f, b.OriginY + b.ZaxisY*f, b.OriginZ + b.ZaxisZ*f, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 
     /// Move a 3D box by a vector. Same as Box.move.
+    [<Obsolete("This was an alias for Box.move, ambiguous with the local-axis translateLocalX/Y/Z members. Use Box.move for a world-space vector, or Box.translateLocalX/Y/Z to move along the box's own axes.")>]
     static member inline translate (v:Vec) (b:Box) : Box =
         Box.createUnchecked(b.OriginX + v.X, b.OriginY + v.Y, b.OriginZ + v.Z, b.XaxisX, b.XaxisY, b.XaxisZ, b.YaxisX, b.YaxisY, b.YaxisZ, b.ZaxisX, b.ZaxisY, b.ZaxisZ)
 

--- a/Src/Rect2D.fs
+++ b/Src/Rect2D.fs
@@ -842,30 +842,35 @@ type Rect2D =
         Rect2D.createUnchecked(r.OriginX + r.YaxisX*f, r.OriginY + r.YaxisY*f, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
     /// Translate by a 2D vector. (Same as Rect2D.move)
+    [<Obsolete("This was an alias for Rect2D.move, ambiguous with the local-axis translateLocalX/Y members. Use Rect2D.move for a world-space vector, or Rect2D.translateLocalX/Y to move along the rectangle's own axes.")>]
     static member translate (v:Vc) (r:Rect2D)  : Rect2D =
         Rect2D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Translate by a 2D vector. (Same as Rect2D.translate)
+    /// Translate by a 2D vector in world space. (Same as Rect2D.Move)
     static member move (v:Vc) (r:Rect2D)  : Rect2D =
         Rect2D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Returns a 2D rectangle moved by a vector. Same as Rect2D.move and Rect2D.translate.
+    /// Returns a 2D rectangle moved by a vector in world space. Same as Rect2D.move.
     member inline r.Move (v:Vc) : Rect2D =
         Rect2D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Returns a 2D rectangle moved by a given distance in X direction.
+    /// Returns a 2D rectangle moved by a given distance along the world X-axis.
+    /// This is not the rectangle's own (possibly rotated) local X-axis, use Rect2D.translateLocalX for that.
     member inline r.MoveX (distance:float) : Rect2D =
         Rect2D.createUnchecked(r.OriginX + distance, r.OriginY, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Returns a 2D rectangle moved by a given distance in X direction.
+    /// Returns a 2D rectangle moved by a given distance along the world X-axis.
+    /// This is not the rectangle's own (possibly rotated) local X-axis, use Rect2D.translateLocalX for that.
     static member inline moveX (distance:float) (r:Rect2D) : Rect2D =
         Rect2D.createUnchecked(r.OriginX + distance, r.OriginY, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Returns a 2D rectangle moved by a given distance in Y direction.
+    /// Returns a 2D rectangle moved by a given distance along the world Y-axis.
+    /// This is not the rectangle's own (possibly rotated) local Y-axis, use Rect2D.translateLocalY for that.
     member inline r.MoveY (distance:float) : Rect2D =
         Rect2D.createUnchecked(r.OriginX, r.OriginY + distance, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 
-    /// Returns a 2D rectangle moved by a given distance in Y direction.
+    /// Returns a 2D rectangle moved by a given distance along the world Y-axis.
+    /// This is not the rectangle's own (possibly rotated) local Y-axis, use Rect2D.translateLocalY for that.
     static member inline moveY (distance:float) (r:Rect2D) : Rect2D =
         Rect2D.createUnchecked(r.OriginX, r.OriginY + distance, r.XaxisX, r.XaxisY, r.YaxisX, r.YaxisY)
 

--- a/Src/Rect3D.fs
+++ b/Src/Rect3D.fs
@@ -375,35 +375,41 @@ type Rect3D =
     static member inline scaleOn (cen:Pnt) (factor:float) (r:Rect3D) : Rect3D =
         r.ScaleOn cen factor
 
-    /// Returns a 3D rectangle moved by a vector. Same as Rect3D.move and Rect3D.translate.
+    /// Returns a 3D rectangle moved by a vector in world space. Same as Rect3D.move.
     member inline r.Move (v:Vec) : Rect3D =
         Rect3D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.OriginZ + v.Z, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Move the 3D rectangle by a vector. Same as Rect3D.translate.
+    /// Move the 3D rectangle by a vector in world space. Same as Rect3D.Move.
     static member move (v:Vec) (r:Rect3D)  : Rect3D =
         Rect3D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.OriginZ + v.Z, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in X direction.
+    /// Returns a 3D rectangle moved by a given distance along the world X-axis.
+    /// This is not the rectangle's own (possibly rotated) local X-axis, use Rect3D.translateLocalX for that.
     member inline r.MoveX (distance:float) : Rect3D =
         Rect3D.createUnchecked(r.OriginX + distance, r.OriginY, r.OriginZ, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in X direction.
+    /// Returns a 3D rectangle moved by a given distance along the world X-axis.
+    /// This is not the rectangle's own (possibly rotated) local X-axis, use Rect3D.translateLocalX for that.
     static member inline moveX (distance:float) (r:Rect3D) : Rect3D =
         Rect3D.createUnchecked(r.OriginX + distance, r.OriginY, r.OriginZ, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in Y direction.
+    /// Returns a 3D rectangle moved by a given distance along the world Y-axis.
+    /// This is not the rectangle's own (possibly rotated) local Y-axis, use Rect3D.translateLocalY for that.
     member inline r.MoveY (distance:float) : Rect3D =
         Rect3D.createUnchecked(r.OriginX, r.OriginY + distance, r.OriginZ, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in Y direction.
+    /// Returns a 3D rectangle moved by a given distance along the world Y-axis.
+    /// This is not the rectangle's own (possibly rotated) local Y-axis, use Rect3D.translateLocalY for that.
     static member inline moveY (distance:float) (r:Rect3D) : Rect3D =
         Rect3D.createUnchecked(r.OriginX, r.OriginY + distance, r.OriginZ, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in Z direction.
+    /// Returns a 3D rectangle moved by a given distance along the world Z-axis.
+    /// This is not the rectangle's own (possibly rotated) local Z-axis, use Rect3D.translateLocalZ for that.
     member inline r.MoveZ (distance:float) : Rect3D =
         Rect3D.createUnchecked(r.OriginX, r.OriginY, r.OriginZ + distance, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Returns a 3D rectangle moved by a given distance in Z direction.
+    /// Returns a 3D rectangle moved by a given distance along the world Z-axis.
+    /// This is not the rectangle's own (possibly rotated) local Z-axis, use Rect3D.translateLocalZ for that.
     static member inline moveZ (distance:float) (r:Rect3D) : Rect3D =
         Rect3D.createUnchecked(r.OriginX, r.OriginY, r.OriginZ + distance, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
@@ -1682,22 +1688,28 @@ type Rect3D =
         Rect3D.createUnchecked(r.OriginX + r.YaxisX*f, r.OriginY + r.YaxisY*f, r.OriginZ + r.YaxisZ*f, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
     /// Translate by a 3D vector. Same as Rect3D.move.
+    [<Obsolete("This was an alias for Rect3D.move, ambiguous with the local-axis translateLocalX/Y/Z members. Use Rect3D.move for a world-space vector, or Rect3D.translateLocalX/Y/Z to move along the rectangle's own axes.")>]
     static member translate (v:Vec) (r:Rect3D)  : Rect3D =
         Rect3D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.OriginZ + v.Z, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Offset or Translate along the local Z-axis.
-    /// The local Z-axis is calculated from Cross Product of X- and Y-axis of the 3D-rectangle.
-    static member offsetZ (offsetDistance :float) (r:Rect3D) : Rect3D =
+    /// Translate along the local Z-axis of the 3D-rectangle. Same as Rect3D.offsetZ.
+    /// The local Z-axis is calculated from the Cross Product of the X- and Y-axis of the 3D-rectangle.
+    static member translateLocalZ (distZ:float) (r:Rect3D) : Rect3D =
         let zX = r.XaxisY*r.YaxisZ - r.XaxisZ*r.YaxisY
         let zY = r.XaxisZ*r.YaxisX - r.XaxisX*r.YaxisZ
         let zZ = r.XaxisX*r.YaxisY - r.XaxisY*r.YaxisX
         let len = XYZ.length zX zY zZ
-        if isTooTiny len then failTooSmall "Rect3D.offsetZ: rect" r
-        let f = offsetDistance/len
+        if isTooTiny len then failTooSmall "Rect3D.translateLocalZ: rect" r
+        let f = distZ/len
         Rect3D.createUnchecked(
             r.OriginX + zX*f, r.OriginY + zY*f, r.OriginZ + zZ*f,
             r.XaxisX, r.XaxisY, r.XaxisZ,
             r.YaxisX, r.YaxisY, r.YaxisZ)
+
+    /// Offset or Translate along the local Z-axis. Same as Rect3D.translateLocalZ.
+    /// The local Z-axis is calculated from Cross Product of X- and Y-axis of the 3D-rectangle.
+    static member offsetZ (offsetDistance :float) (r:Rect3D) : Rect3D =
+        Rect3D.translateLocalZ offsetDistance r
 
     /// Offset a Rect3D like a Polyline inwards by a given distance.
     /// Negative distances will offset outwards.

--- a/Src/Rect3D.fs
+++ b/Src/Rect3D.fs
@@ -1692,8 +1692,10 @@ type Rect3D =
     static member translate (v:Vec) (r:Rect3D)  : Rect3D =
         Rect3D.createUnchecked(r.OriginX + v.X, r.OriginY + v.Y, r.OriginZ + v.Z, r.XaxisX, r.XaxisY, r.XaxisZ, r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Translate along the local Z-axis of the 3D-rectangle. Same as Rect3D.offsetZ.
+    /// Moves the 3D-rectangle rigidly along its local Z-axis by the given distance. Same as Rect3D.offsetZ.
     /// The local Z-axis is calculated from the Cross Product of the X- and Y-axis of the 3D-rectangle.
+    /// The rectangle's Origin moves but its SizeX, SizeY and axes are unchanged.
+    /// This is unrelated to Rect3D.offset, which resizes the rectangle in its own plane instead of moving it.
     static member translateLocalZ (distZ:float) (r:Rect3D) : Rect3D =
         let zX = r.XaxisY*r.YaxisZ - r.XaxisZ*r.YaxisY
         let zY = r.XaxisZ*r.YaxisX - r.XaxisX*r.YaxisZ
@@ -1706,14 +1708,19 @@ type Rect3D =
             r.XaxisX, r.XaxisY, r.XaxisZ,
             r.YaxisX, r.YaxisY, r.YaxisZ)
 
-    /// Offset or Translate along the local Z-axis. Same as Rect3D.translateLocalZ.
+    /// Moves the 3D-rectangle rigidly along its local Z-axis by the given distance. Same as Rect3D.translateLocalZ.
     /// The local Z-axis is calculated from Cross Product of X- and Y-axis of the 3D-rectangle.
+    /// The rectangle's Origin moves but its SizeX, SizeY and axes are unchanged.
+    /// This is unrelated to Rect3D.offset, which resizes the rectangle in its own plane instead of moving it.
     static member offsetZ (offsetDistance :float) (r:Rect3D) : Rect3D =
         Rect3D.translateLocalZ offsetDistance r
 
-    /// Offset a Rect3D like a Polyline inwards by a given distance.
-    /// Negative distances will offset outwards.
+    /// Resizes a Rect3D like a Polyline offset, shrinking it inwards on all four edges by a given distance,
+    /// within the rectangle's own X-Y plane. The rectangle stays in the same plane; SizeX and SizeY shrink
+    /// by twice the distance and the Origin re-centers, but the rectangle does not move along its local Z-axis.
+    /// Negative distances will offset outwards, growing the rectangle instead.
     /// Fails if the distance is larger than half the size of the rectangle.
+    /// This is unrelated to Rect3D.offsetZ / translateLocalZ, which move the rectangle instead of resizing it.
     static member offset dist (rect:Rect3D) : Rect3D =
         let xl = rect.SizeX
         let yl = rect.SizeY

--- a/Src/TypeExtensions/PPlane.fs
+++ b/Src/TypeExtensions/PPlane.fs
@@ -606,10 +606,11 @@ module AutoOpenPPlane =
             PPlane.createUnchecked(pl.OriginX * factor, pl.OriginY * factor, pl.OriginZ * factor, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
         /// Move plane origin by vector. Same as PPlane.move.
+        [<Obsolete("This was an alias for PPlane.move, ambiguous with the local-axis translateLocalX/Y/Z members. Use PPlane.move (or translateBy) for a world-space vector, or PPlane.translateLocalX/Y/Z to move along the plane's own axes.")>]
         static member inline translate (translation:Vec) (pl:PPlane)  : PPlane =
             PPlane.createUnchecked(pl.OriginX + translation.X, pl.OriginY + translation.Y, pl.OriginZ + translation.Z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
-        /// Move plane origin by vector. Same as PPlane.translate.
+        /// Move plane origin by vector in world space. Same as PPlane.translateBy.
         static member inline move (translation:Vec) (pl:PPlane)  : PPlane =
             PPlane.createUnchecked(pl.OriginX + translation.X, pl.OriginY + translation.Y, pl.OriginZ + translation.Z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 

--- a/Test/TestAPI.fs
+++ b/Test/TestAPI.fs
@@ -1982,6 +1982,7 @@ module Rect3DAPI =
     let (_:Rect3D) = Rect3D.translate (Vec(1., 1., 1.)) rect3d
     let (_:Rect3D) = Rect3D.translateLocalX 1.0 rect3d
     let (_:Rect3D) = Rect3D.translateLocalY 1.0 rect3d
+    let (_:Rect3D) = Rect3D.translateLocalZ 1.0 rect3d
     let (_:Rect3D) = Rect3D.move (Vec(1., 1., 1.)) rect3d
     let (_:Rect3D) = Rect3D.transformRigid (RigidMatrix.identity) rect3d
     let (_:Rect3D) = Rect3D.scale 2.0 rect3d

--- a/Test/TestBox.fs
+++ b/Test/TestBox.fs
@@ -1,5 +1,7 @@
 module TestBox
 
+#nowarn "44" // Box.translate is obsolete; still exercised here for backward-compatibility coverage.
+
 open Euclid
 
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
@@ -293,7 +295,7 @@ let tests =
                 Expect.isTrue (eqPnt moved.Origin (Pnt(0., 0., 2.))) "Origin should be moved in Z"
             }
 
-            test "translate static method" {
+            test "obsolete translate static method is still an alias for move" {
                 let box = Box.createUncheckedVec(Pnt(0., 0., 0.), Vec(10., 0., 0.), Vec(0., 5., 0.), Vec(0., 0., 3.))
                 let moved = Box.translate (Vec(5., 3., 2.)) box
                 Expect.isTrue (eqPnt moved.Origin (Pnt(5., 3., 2.))) "Origin should be translated"

--- a/Test/TestPlane.fs
+++ b/Test/TestPlane.fs
@@ -1,5 +1,7 @@
 module TestPlane
 
+#nowarn "44" // PPlane.translate is obsolete; still exercised here for backward-compatibility coverage.
+
 open Euclid
 
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
@@ -522,7 +524,7 @@ let tests =
                 Expect.isTrue (eqVec moved.Xaxis.AsVec (UnitVec.Xaxis.AsVec)) "Axes should be unchanged"
             }
 
-            test "translate is alias for move" {
+            test "obsolete translate is still an alias for move" {
                 let plane = PPlane.WorldXY
                 let moved = PPlane.translate (Vec(5., 5., 5.)) plane
                 Expect.isTrue (eqPnt moved.Origin (Pnt(5., 5., 5.))) "Origin should be moved"

--- a/Test/TestRect2D.fs
+++ b/Test/TestRect2D.fs
@@ -1,5 +1,7 @@
 module TestRect2D
 
+#nowarn "44" // Rect2D.translate is obsolete; still exercised here for backward-compatibility coverage.
+
 open Euclid
 
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
@@ -388,11 +390,11 @@ let tests =
                 "notEquals false" |> Expect.isFalse (Rect2D.notEquals 0.0 rr rr)
             }
             test "within tolerance" {
-                let r2 = Rect2D.translate (Vc(1e-10, 0.)) rr
+                let r2 = Rect2D.move (Vc(1e-10, 0.)) rr
                 "equals within tol" |> Expect.isTrue (Rect2D.equals 1e-9 rr r2)
             }
             test "not equal when moved" {
-                let r2 = Rect2D.translate (Vc(1., 0.)) rr
+                let r2 = Rect2D.move (Vc(1., 0.)) rr
                 "notEquals true"  |> Expect.isTrue (Rect2D.notEquals 1e-9 rr r2)
                 "equals false"    |> Expect.isFalse (Rect2D.equals 1e-9 rr r2)
             }
@@ -440,7 +442,7 @@ let tests =
         // Translation
         // ---------------------------------------------------------------------
         testList "Translation" [
-            test "translate / move are equal" {
+            test "obsolete translate is still an alias for move" {
                 let a = Rect2D.translate (Vc(1., 2.)) rr
                 let b = Rect2D.move (Vc(1., 2.)) rr
                 "origin moved" |> Expect.isTrue (eq a.Origin (Pt(6., 5.)))

--- a/Test/TestRect3D.fs
+++ b/Test/TestRect3D.fs
@@ -231,6 +231,14 @@ let tests =
                 let down = Rect3D.offsetZ -3.0 r
                 "offsetZ neg origin" |> Expect.isTrue (eq down.Origin (Pnt(0.,0.,-3.)))
             }
+
+            test "Rect3D.translateLocalZ is same as offsetZ" {
+                let r = Rect3D.createFromVectors(Pnt(0.,0.,0.), Vec(4.,0.,0.), Vec(0.,2.,0.))
+                let a = Rect3D.translateLocalZ 5.0 r
+                let b = Rect3D.offsetZ 5.0 r
+                "translateLocalZ origin" |> Expect.isTrue (eq a.Origin (Pnt(0.,0.,5.)))
+                "translateLocalZ = offsetZ" |> Expect.isTrue (Rect3D.equals 1e-9 a b)
+            }
         ]
 
         testList "Rect3D offsets" [


### PR DESCRIPTION
Box, Rect2D, Rect3D, and PPlane all have local X/Y(/Z) axes and expose
translateLocalX/Y/Z members that move along them. Their bare `translate`
(vector) member was defined as a literal alias of `move` (a world-space
vector translation), which made "translate" ambiguous between world-space
and local-axis semantics. Mark these `translate` overloads Obsolete,
pointing callers at `move` (world vector) or `translateLocalX/Y/Z` (local
axis) instead.

Also clarify the MoveX/Y/Z docstrings on Box, Rect2D, and Rect3D: they
move along the world X/Y/Z axes, not the shape's own (possibly rotated)
local axes, which the previous wording did not make clear.

Add Rect3D.translateLocalZ as an alias of the existing offsetZ, for
naming consistency with Box.translateLocalX/Y/Z and Rect3D's own
translateLocalX/Y.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0141VrsM3Qh28rusn8mbBQQo