### PR TITLE
Add reverse-direction edge members to Rect2D, Rect3D, BRect, Box, BBox, FreeBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `Rect2D`, `Rect3D`, `BRect`, `Box`, `BBox`, and `FreeBox` now have a reverse-direction instance and static member for every named edge (e.g. `Edge10` next to `Edge01`, `Edge23` next to `Edge32`), so every edge can be addressed in either direction.
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
 - Added `Polyline3D.TryPlane` and `Polyline3D.IsPlanar`, plus the static `tryPlane` and `isPlanar`, to get the `NPlane` of a planar Polyline3D within a tolerance.
 - Added `Polyline3D.AveragePlane` and `Polyline3D.TryAveragePlane`, plus the static `averagePlane` and `tryAveragePlane`, to get the average `NPlane` of a Polyline3D even when its points are not planar.
 - Added `Polyline3D.TryAverageNormal` and the static `tryAverageNormal`, returning `None` instead of failing where `AverageNormal` finds no normal.
 - The unsafe internal constructors of `NPlane`, `PPlane`, `Box`, `BRect`, and `BBox`, and therefore all their `createUnchecked` members, now verify their input when compiled in DEBUG mode or with the `CHECKED_EUCLID` symbol defined. This covers unitized normals and axes, perpendicular and right-handed frames, `NaN` and `Infinity` values, and min values not being bigger than max values. The other unsafe constructors already did this.
 - Documented the `CHECKED_EUCLID` compiler flag in the Readme.
+
+### Removed
+- The obsolete numeric `Edge0`-`Edge11` instance members on `Box` and `FreeBox` (deprecated aliases for the endpoint-named edges) have been removed; `Edge10` is now used for the reverse of `Edge01` instead.
 
 ### Changed
 - `Polyline3D.AverageNormal` now fails if no normal can be found, instead of silently returning an almost zero length vector. This is the case if the Polyline3D has less than 3 points, if all points are in one line, if the cross products cancel each other out on a self intersecting shape, or if the Polyline3D is very small. Use `Polyline3D.TryAverageNormal` to get `None` instead of an exception.

--- a/Src/BBox.fs
+++ b/Src/BBox.fs
@@ -1167,6 +1167,102 @@ type BBox =
     static member inline edge47 (b:BBox) : Line3D =
         b.Edge47
 
+    /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
+    member inline b.Edge10 : Line3D =
+        b.Edge01.Reversed
+
+    /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
+    static member inline edge10 (b:BBox) : Line3D =
+        b.Edge10
+
+    /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
+    member inline b.Edge21 : Line3D =
+        b.Edge12.Reversed
+
+    /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
+    static member inline edge21 (b:BBox) : Line3D =
+        b.Edge21
+
+    /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
+    member inline b.Edge23 : Line3D =
+        b.Edge32.Reversed
+
+    /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
+    static member inline edge23 (b:BBox) : Line3D =
+        b.Edge23
+
+    /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
+    member inline b.Edge30 : Line3D =
+        b.Edge03.Reversed
+
+    /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
+    static member inline edge30 (b:BBox) : Line3D =
+        b.Edge30
+
+    /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
+    member inline b.Edge40 : Line3D =
+        b.Edge04.Reversed
+
+    /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
+    static member inline edge40 (b:BBox) : Line3D =
+        b.Edge40
+
+    /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
+    member inline b.Edge51 : Line3D =
+        b.Edge15.Reversed
+
+    /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
+    static member inline edge51 (b:BBox) : Line3D =
+        b.Edge51
+
+    /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
+    member inline b.Edge62 : Line3D =
+        b.Edge26.Reversed
+
+    /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
+    static member inline edge62 (b:BBox) : Line3D =
+        b.Edge62
+
+    /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
+    member inline b.Edge73 : Line3D =
+        b.Edge37.Reversed
+
+    /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
+    static member inline edge73 (b:BBox) : Line3D =
+        b.Edge73
+
+    /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
+    member inline b.Edge54 : Line3D =
+        b.Edge45.Reversed
+
+    /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
+    static member inline edge54 (b:BBox) : Line3D =
+        b.Edge54
+
+    /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
+    member inline b.Edge65 : Line3D =
+        b.Edge56.Reversed
+
+    /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
+    static member inline edge65 (b:BBox) : Line3D =
+        b.Edge65
+
+    /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
+    member inline b.Edge67 : Line3D =
+        b.Edge76.Reversed
+
+    /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
+    static member inline edge67 (b:BBox) : Line3D =
+        b.Edge67
+
+    /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
+    member inline b.Edge74 : Line3D =
+        b.Edge47.Reversed
+
+    /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
+    static member inline edge74 (b:BBox) : Line3D =
+        b.Edge74
+
     /// <summary>Returns the 12 edges of this 3D bounding box as an array of 12 Lines.
     /// Pairs in this order:
     /// 0-1, 1-2, 3-2, 0-3, 0-4, 1-5, 2-6, 3-7, 4-5, 5-6, 7-6, 4-7

--- a/Src/BBox.fs
+++ b/Src/BBox.fs
@@ -1169,7 +1169,7 @@ type BBox =
 
     /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
     member inline b.Edge10 : Line3D =
-        b.Edge01.Reversed
+        Line3D(b.MaxX, b.MinY, b.MinZ, b.MinX, b.MinY, b.MinZ)
 
     /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
     static member inline edge10 (b:BBox) : Line3D =
@@ -1177,7 +1177,7 @@ type BBox =
 
     /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
     member inline b.Edge21 : Line3D =
-        b.Edge12.Reversed
+        Line3D(b.MaxX, b.MaxY, b.MinZ, b.MaxX, b.MinY, b.MinZ)
 
     /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
     static member inline edge21 (b:BBox) : Line3D =
@@ -1185,7 +1185,7 @@ type BBox =
 
     /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
     member inline b.Edge23 : Line3D =
-        b.Edge32.Reversed
+        Line3D(b.MaxX, b.MaxY, b.MinZ, b.MinX, b.MaxY, b.MinZ)
 
     /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
     static member inline edge23 (b:BBox) : Line3D =
@@ -1193,7 +1193,7 @@ type BBox =
 
     /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
     member inline b.Edge30 : Line3D =
-        b.Edge03.Reversed
+        Line3D(b.MinX, b.MaxY, b.MinZ, b.MinX, b.MinY, b.MinZ)
 
     /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
     static member inline edge30 (b:BBox) : Line3D =
@@ -1201,7 +1201,7 @@ type BBox =
 
     /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
     member inline b.Edge40 : Line3D =
-        b.Edge04.Reversed
+        Line3D(b.MinX, b.MinY, b.MaxZ, b.MinX, b.MinY, b.MinZ)
 
     /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
     static member inline edge40 (b:BBox) : Line3D =
@@ -1209,7 +1209,7 @@ type BBox =
 
     /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
     member inline b.Edge51 : Line3D =
-        b.Edge15.Reversed
+        Line3D(b.MaxX, b.MinY, b.MaxZ, b.MaxX, b.MinY, b.MinZ)
 
     /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
     static member inline edge51 (b:BBox) : Line3D =
@@ -1217,7 +1217,7 @@ type BBox =
 
     /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
     member inline b.Edge62 : Line3D =
-        b.Edge26.Reversed
+        Line3D(b.MaxX, b.MaxY, b.MaxZ, b.MaxX, b.MaxY, b.MinZ)
 
     /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
     static member inline edge62 (b:BBox) : Line3D =
@@ -1225,7 +1225,7 @@ type BBox =
 
     /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
     member inline b.Edge73 : Line3D =
-        b.Edge37.Reversed
+        Line3D(b.MinX, b.MaxY, b.MaxZ, b.MinX, b.MaxY, b.MinZ)
 
     /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
     static member inline edge73 (b:BBox) : Line3D =
@@ -1233,7 +1233,7 @@ type BBox =
 
     /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
     member inline b.Edge54 : Line3D =
-        b.Edge45.Reversed
+        Line3D(b.MaxX, b.MinY, b.MaxZ, b.MinX, b.MinY, b.MaxZ)
 
     /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
     static member inline edge54 (b:BBox) : Line3D =
@@ -1241,7 +1241,7 @@ type BBox =
 
     /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
     member inline b.Edge65 : Line3D =
-        b.Edge56.Reversed
+        Line3D(b.MaxX, b.MaxY, b.MaxZ, b.MaxX, b.MinY, b.MaxZ)
 
     /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
     static member inline edge65 (b:BBox) : Line3D =
@@ -1249,7 +1249,7 @@ type BBox =
 
     /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
     member inline b.Edge67 : Line3D =
-        b.Edge76.Reversed
+        Line3D(b.MaxX, b.MaxY, b.MaxZ, b.MinX, b.MaxY, b.MaxZ)
 
     /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
     static member inline edge67 (b:BBox) : Line3D =
@@ -1257,7 +1257,7 @@ type BBox =
 
     /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
     member inline b.Edge74 : Line3D =
-        b.Edge47.Reversed
+        Line3D(b.MinX, b.MaxY, b.MaxZ, b.MinX, b.MinY, b.MaxZ)
 
     /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
     static member inline edge74 (b:BBox) : Line3D =

--- a/Src/BRect.fs
+++ b/Src/BRect.fs
@@ -827,6 +827,98 @@ type BRect =
     static member inline edge30 (r:BRect) : Line2D =
         r.Edge30
 
+    /// <summary>The bottom edge reversed. The line from point 1 to 0. This is the reverse of Edge01.
+    /// <code>
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2  = max X,Y
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   +------------+-----> X-axis
+    ///  0 = min X,Y    1
+    /// </code>
+    /// </summary>
+    member r.Edge10 : Line2D =
+        r.Edge01.Reversed
+
+    /// The bottom edge reversed. The line from point 1 to 0. This is the reverse of Edge01.
+    static member inline edge10 (r:BRect) : Line2D =
+        r.Edge10
+
+    /// <summary>The right edge reversed. The line from point 2 to 1. This is the reverse of Edge12.
+    /// <code>
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2  = max X,Y
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   +------------+-----> X-axis
+    ///  0 = min X,Y    1
+    /// </code>
+    /// </summary>
+    member r.Edge21 : Line2D =
+        r.Edge12.Reversed
+
+    /// The right edge reversed. The line from point 2 to 1. This is the reverse of Edge12.
+    static member inline edge21 (r:BRect) : Line2D =
+        r.Edge21
+
+    /// <summary>The top edge reversed. The line from point 3 to 2. This is the reverse of Edge23.
+    /// <code>
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2  = max X,Y
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   +------------+-----> X-axis
+    ///  0 = min X,Y    1
+    /// </code>
+    /// </summary>
+    member r.Edge32 : Line2D =
+        r.Edge23.Reversed
+
+    /// The top edge reversed. The line from point 3 to 2. This is the reverse of Edge23.
+    static member inline edge32 (r:BRect) : Line2D =
+        r.Edge32
+
+    /// <summary>The left edge reversed. The line from point 0 to 3. This is the reverse of Edge30.
+    /// <code>
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2  = max X,Y
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   +------------+-----> X-axis
+    ///  0 = min X,Y    1
+    /// </code>
+    /// </summary>
+    member r.Edge03 : Line2D =
+        r.Edge30.Reversed
+
+    /// The left edge reversed. The line from point 0 to 3. This is the reverse of Edge30.
+    static member inline edge03 (r:BRect) : Line2D =
+        r.Edge03
+
     /// <summary>Returns all 4 edges of this bounding rectangle in counter-clockwise order: Edge01, Edge12, Edge23 and Edge30.
     /// <code>
     ///   Y-axis

--- a/Src/BRect.fs
+++ b/Src/BRect.fs
@@ -844,7 +844,7 @@ type BRect =
     /// </code>
     /// </summary>
     member r.Edge10 : Line2D =
-        r.Edge01.Reversed
+        Line2D(r.MaxX,r.MinY,r.MinX,r.MinY)
 
     /// The bottom edge reversed. The line from point 1 to 0. This is the reverse of Edge01.
     static member inline edge10 (r:BRect) : Line2D =
@@ -867,7 +867,7 @@ type BRect =
     /// </code>
     /// </summary>
     member r.Edge21 : Line2D =
-        r.Edge12.Reversed
+        Line2D(r.MaxX,r.MaxY,r.MaxX,r.MinY)
 
     /// The right edge reversed. The line from point 2 to 1. This is the reverse of Edge12.
     static member inline edge21 (r:BRect) : Line2D =
@@ -890,7 +890,7 @@ type BRect =
     /// </code>
     /// </summary>
     member r.Edge32 : Line2D =
-        r.Edge23.Reversed
+        Line2D(r.MinX,r.MaxY,r.MaxX,r.MaxY)
 
     /// The top edge reversed. The line from point 3 to 2. This is the reverse of Edge23.
     static member inline edge32 (r:BRect) : Line2D =
@@ -913,7 +913,7 @@ type BRect =
     /// </code>
     /// </summary>
     member r.Edge03 : Line2D =
-        r.Edge30.Reversed
+        Line2D(r.MinX,r.MinY,r.MinX,r.MaxY)
 
     /// The left edge reversed. The line from point 0 to 3. This is the reverse of Edge30.
     static member inline edge03 (r:BRect) : Line2D =

--- a/Src/Box.fs
+++ b/Src/Box.fs
@@ -2096,6 +2096,222 @@ type Box =
     static member inline edge37 (b:Box) : Line3D =
         b.Edge37
 
+    /// <summary>Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge10 : Line3D =
+        b.Edge01.Reversed
+
+    /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
+    static member inline edge10 (b:Box) : Line3D =
+        b.Edge10
+
+    /// <summary>Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge21 : Line3D =
+        b.Edge12.Reversed
+
+    /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
+    static member inline edge21 (b:Box) : Line3D =
+        b.Edge21
+
+    /// <summary>Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge23 : Line3D =
+        b.Edge32.Reversed
+
+    /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
+    static member inline edge23 (b:Box) : Line3D =
+        b.Edge23
+
+    /// <summary>Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge30 : Line3D =
+        b.Edge03.Reversed
+
+    /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
+    static member inline edge30 (b:Box) : Line3D =
+        b.Edge30
+
+    /// <summary>Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge54 : Line3D =
+        b.Edge45.Reversed
+
+    /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
+    static member inline edge54 (b:Box) : Line3D =
+        b.Edge54
+
+    /// <summary>Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge65 : Line3D =
+        b.Edge56.Reversed
+
+    /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
+    static member inline edge65 (b:Box) : Line3D =
+        b.Edge65
+
+    /// <summary>Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge67 : Line3D =
+        b.Edge76.Reversed
+
+    /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
+    static member inline edge67 (b:Box) : Line3D =
+        b.Edge67
+
+    /// <summary>Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge74 : Line3D =
+        b.Edge47.Reversed
+
+    /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
+    static member inline edge74 (b:Box) : Line3D =
+        b.Edge74
+
+    /// <summary>Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge40 : Line3D =
+        b.Edge04.Reversed
+
+    /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
+    static member inline edge40 (b:Box) : Line3D =
+        b.Edge40
+
+    /// <summary>Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge51 : Line3D =
+        b.Edge15.Reversed
+
+    /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
+    static member inline edge51 (b:Box) : Line3D =
+        b.Edge51
+
+    /// <summary>Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge62 : Line3D =
+        b.Edge26.Reversed
+
+    /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
+    static member inline edge62 (b:Box) : Line3D =
+        b.Edge62
+
+    /// <summary>Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
+    /// <code>
+    ///   7------6
+    ///  /|     /|
+    /// 4------5 |
+    /// | |    | |
+    /// | 3----|-2
+    /// |/     |/
+    /// 0------1
+    /// </code>
+    /// </summary>
+    member inline b.Edge73 : Line3D =
+        b.Edge37.Reversed
+
+    /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
+    static member inline edge73 (b:Box) : Line3D =
+        b.Edge73
+
 
     /// <summary>Returns the edge of the box at the specified index.
     /// The order of the edges is: 0-1, 1-2, 3-2, 0-3, 0-4, 1-5, 2-6, 3-7, 4-5, 5-6, 7-6, 4-7
@@ -2172,43 +2388,6 @@ type Box =
 
     // #endregion
     // #region Obsolete
-
-
-    [<Obsolete("Use .Edge01 instead.")>]
-    member inline b.Edge0 : Line3D = b.Edge01
-
-    [<Obsolete("Use .Edge12 instead.")>]
-    member inline b.Edge1 : Line3D = b.Edge12
-
-    [<Obsolete("Use .Edge32 instead.")>]
-    member inline b.Edge2 : Line3D = b.Edge32
-
-    [<Obsolete("Use .Edge03 instead.")>]
-    member inline b.Edge3 : Line3D = b.Edge03
-
-    [<Obsolete("Use .Edge45 instead.")>]
-    member inline b.Edge4 : Line3D = b.Edge45
-
-    [<Obsolete("Use .Edge56 instead.")>]
-    member inline b.Edge5 : Line3D = b.Edge56
-
-    [<Obsolete("Use .Edge76 instead.")>]
-    member inline b.Edge6 : Line3D = b.Edge76
-
-    [<Obsolete("Use .Edge47 instead.")>]
-    member inline b.Edge7 : Line3D = b.Edge47
-
-    [<Obsolete("Use .Edge04 instead.")>]
-    member inline b.Edge8 : Line3D = b.Edge04
-
-    [<Obsolete("Use .Edge15 instead.")>]
-    member inline b.Edge9 : Line3D = b.Edge15
-
-    [<Obsolete("Use .Edge26 instead.")>]
-    member inline b.Edge10 : Line3D = b.Edge26
-
-    [<Obsolete("Use .Edge37 instead.")>]
-    member inline b.Edge11 : Line3D = b.Edge37
 
     [<Obsolete("This is actually the volume, also this does not scale proportionally, use .Volume")>]
     member inline r.AreaSq : float =

--- a/Src/Box.fs
+++ b/Src/Box.fs
@@ -2108,7 +2108,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge10 : Line3D =
-        b.Edge01.Reversed
+        Line3D(b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ,
+               b.OriginX, b.OriginY, b.OriginZ)
 
     /// Returns the X-aligned edge from point 1 to 0. This is the reverse of Edge01.
     static member inline edge10 (b:Box) : Line3D =
@@ -2126,7 +2127,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge21 : Line3D =
-        b.Edge12.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ,
+               b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ)
 
     /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
     static member inline edge21 (b:Box) : Line3D =
@@ -2144,7 +2146,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge23 : Line3D =
-        b.Edge32.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ,
+               b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ)
 
     /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
     static member inline edge23 (b:Box) : Line3D =
@@ -2162,7 +2165,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge30 : Line3D =
-        b.Edge03.Reversed
+        Line3D(b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ,
+               b.OriginX, b.OriginY, b.OriginZ)
 
     /// Returns the Y-aligned edge from point 3 to 0. This is the reverse of Edge03.
     static member inline edge30 (b:Box) : Line3D =
@@ -2180,7 +2184,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge54 : Line3D =
-        b.Edge45.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ,
+               b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ)
 
     /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
     static member inline edge54 (b:Box) : Line3D =
@@ -2198,7 +2203,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge65 : Line3D =
-        b.Edge56.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
+               b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ)
 
     /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
     static member inline edge65 (b:Box) : Line3D =
@@ -2216,7 +2222,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge67 : Line3D =
-        b.Edge76.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
+               b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ)
 
     /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
     static member inline edge67 (b:Box) : Line3D =
@@ -2234,7 +2241,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge74 : Line3D =
-        b.Edge47.Reversed
+        Line3D(b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ,
+               b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ)
 
     /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
     static member inline edge74 (b:Box) : Line3D =
@@ -2252,7 +2260,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge40 : Line3D =
-        b.Edge04.Reversed
+        Line3D(b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ,
+               b.OriginX, b.OriginY, b.OriginZ)
 
     /// Returns the Z-aligned edge from point 4 to 0. This is the reverse of Edge04.
     static member inline edge40 (b:Box) : Line3D =
@@ -2270,7 +2279,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge51 : Line3D =
-        b.Edge15.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ,
+               b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ)
 
     /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
     static member inline edge51 (b:Box) : Line3D =
@@ -2288,7 +2298,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge62 : Line3D =
-        b.Edge26.Reversed
+        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
+               b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ)
 
     /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
     static member inline edge62 (b:Box) : Line3D =
@@ -2306,7 +2317,8 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge73 : Line3D =
-        b.Edge37.Reversed
+        Line3D(b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ,
+               b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ)
 
     /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
     static member inline edge73 (b:Box) : Line3D =

--- a/Src/Box.fs
+++ b/Src/Box.fs
@@ -1789,8 +1789,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge12 : Line3D =
-        Line3D(b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ)
+        let p1x = b.OriginX + b.XaxisX
+        let p1y = b.OriginY + b.XaxisY
+        let p1z = b.OriginZ + b.XaxisZ
+        Line3D(p1x, p1y, p1z, p1x + b.YaxisX, p1y + b.YaxisY, p1z + b.YaxisZ)
 
     /// <summary>Returns the Y-aligned edge from point 1 to 2.
     /// <code>
@@ -1818,8 +1820,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge32 : Line3D =
-        Line3D(b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ)
+        let p3x = b.OriginX + b.YaxisX
+        let p3y = b.OriginY + b.YaxisY
+        let p3z = b.OriginZ + b.YaxisZ
+        Line3D(p3x, p3y, p3z, p3x + b.XaxisX, p3y + b.XaxisY, p3z + b.XaxisZ)
 
     /// <summary>Returns the X-aligned edge from point 3 to 2.
     /// <code>
@@ -1876,8 +1880,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge45 : Line3D =
-        Line3D(b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ)
+        let p4x = b.OriginX + b.ZaxisX
+        let p4y = b.OriginY + b.ZaxisY
+        let p4z = b.OriginZ + b.ZaxisZ
+        Line3D(p4x, p4y, p4z, p4x + b.XaxisX, p4y + b.XaxisY, p4z + b.XaxisZ)
 
     /// <summary>Returns the X-aligned edge from point 4 to 5.
     /// <code>
@@ -1905,8 +1911,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge56 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ)
+        let p5x = b.OriginX + b.XaxisX + b.ZaxisX
+        let p5y = b.OriginY + b.XaxisY + b.ZaxisY
+        let p5z = b.OriginZ + b.XaxisZ + b.ZaxisZ
+        Line3D(p5x, p5y, p5z, p5x + b.YaxisX, p5y + b.YaxisY, p5z + b.YaxisZ)
 
     /// <summary>Returns the Y-aligned edge from point 5 to 6.
     /// <code>
@@ -1934,8 +1942,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge76 : Line3D =
-        Line3D(b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ)
+        let p7x = b.OriginX + b.YaxisX + b.ZaxisX
+        let p7y = b.OriginY + b.YaxisY + b.ZaxisY
+        let p7z = b.OriginZ + b.YaxisZ + b.ZaxisZ
+        Line3D(p7x, p7y, p7z, p7x + b.XaxisX, p7y + b.XaxisY, p7z + b.XaxisZ)
 
     /// <summary>Returns the X-aligned edge from point 7 to 6.
     /// <code>
@@ -1963,8 +1973,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge47 : Line3D =
-        Line3D(b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ,
-               b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ)
+        let p4x = b.OriginX + b.ZaxisX
+        let p4y = b.OriginY + b.ZaxisY
+        let p4z = b.OriginZ + b.ZaxisZ
+        Line3D(p4x, p4y, p4z, p4x + b.YaxisX, p4y + b.YaxisY, p4z + b.YaxisZ)
 
     /// <summary>Returns the Y-aligned edge from point 4 to 7.
     /// <code>
@@ -2021,8 +2033,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge15 : Line3D =
-        Line3D(b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ,
-               b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ)
+        let p1x = b.OriginX + b.XaxisX
+        let p1y = b.OriginY + b.XaxisY
+        let p1z = b.OriginZ + b.XaxisZ
+        Line3D(p1x, p1y, p1z, p1x + b.ZaxisX, p1y + b.ZaxisY, p1z + b.ZaxisZ)
 
     /// <summary>Returns the Z-aligned edge from point 1 to 5.
     /// <code>
@@ -2050,8 +2064,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge26 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ)
+        let p2x = b.OriginX + b.XaxisX + b.YaxisX
+        let p2y = b.OriginY + b.XaxisY + b.YaxisY
+        let p2z = b.OriginZ + b.XaxisZ + b.YaxisZ
+        Line3D(p2x, p2y, p2z, p2x + b.ZaxisX, p2y + b.ZaxisY, p2z + b.ZaxisZ)
 
     /// <summary>Returns the Z-aligned edge from point 2 to 6.
     /// <code>
@@ -2079,8 +2095,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge37 : Line3D =
-        Line3D(b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ,
-               b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ)
+        let p3x = b.OriginX + b.YaxisX
+        let p3y = b.OriginY + b.YaxisY
+        let p3z = b.OriginZ + b.YaxisZ
+        Line3D(p3x, p3y, p3z, p3x + b.ZaxisX, p3y + b.ZaxisY, p3z + b.ZaxisZ)
 
     /// <summary>Returns the Z-aligned edge from point 3 to 7.
     /// <code>
@@ -2127,8 +2145,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge21 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ,
-               b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ)
+        let p1x = b.OriginX + b.XaxisX
+        let p1y = b.OriginY + b.XaxisY
+        let p1z = b.OriginZ + b.XaxisZ
+        Line3D(p1x + b.YaxisX, p1y + b.YaxisY, p1z + b.YaxisZ, p1x, p1y, p1z)
 
     /// Returns the Y-aligned edge from point 2 to 1. This is the reverse of Edge12.
     static member inline edge21 (b:Box) : Line3D =
@@ -2146,8 +2166,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge23 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ,
-               b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ)
+        let p3x = b.OriginX + b.YaxisX
+        let p3y = b.OriginY + b.YaxisY
+        let p3z = b.OriginZ + b.YaxisZ
+        Line3D(p3x + b.XaxisX, p3y + b.XaxisY, p3z + b.XaxisZ, p3x, p3y, p3z)
 
     /// Returns the X-aligned edge from point 2 to 3. This is the reverse of Edge32.
     static member inline edge23 (b:Box) : Line3D =
@@ -2184,8 +2206,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge54 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ,
-               b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ)
+        let p4x = b.OriginX + b.ZaxisX
+        let p4y = b.OriginY + b.ZaxisY
+        let p4z = b.OriginZ + b.ZaxisZ
+        Line3D(p4x + b.XaxisX, p4y + b.XaxisY, p4z + b.XaxisZ, p4x, p4y, p4z)
 
     /// Returns the X-aligned edge from point 5 to 4. This is the reverse of Edge45.
     static member inline edge54 (b:Box) : Line3D =
@@ -2203,8 +2227,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge65 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ)
+        let p5x = b.OriginX + b.XaxisX + b.ZaxisX
+        let p5y = b.OriginY + b.XaxisY + b.ZaxisY
+        let p5z = b.OriginZ + b.XaxisZ + b.ZaxisZ
+        Line3D(p5x + b.YaxisX, p5y + b.YaxisY, p5z + b.YaxisZ, p5x, p5y, p5z)
 
     /// Returns the Y-aligned edge from point 6 to 5. This is the reverse of Edge56.
     static member inline edge65 (b:Box) : Line3D =
@@ -2222,8 +2248,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge67 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ)
+        let p7x = b.OriginX + b.YaxisX + b.ZaxisX
+        let p7y = b.OriginY + b.YaxisY + b.ZaxisY
+        let p7z = b.OriginZ + b.YaxisZ + b.ZaxisZ
+        Line3D(p7x + b.XaxisX, p7y + b.XaxisY, p7z + b.XaxisZ, p7x, p7y, p7z)
 
     /// Returns the X-aligned edge from point 6 to 7. This is the reverse of Edge76.
     static member inline edge67 (b:Box) : Line3D =
@@ -2241,8 +2269,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge74 : Line3D =
-        Line3D(b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.ZaxisX, b.OriginY + b.ZaxisY, b.OriginZ + b.ZaxisZ)
+        let p4x = b.OriginX + b.ZaxisX
+        let p4y = b.OriginY + b.ZaxisY
+        let p4z = b.OriginZ + b.ZaxisZ
+        Line3D(p4x + b.YaxisX, p4y + b.YaxisY, p4z + b.YaxisZ, p4x, p4y, p4z)
 
     /// Returns the Y-aligned edge from point 7 to 4. This is the reverse of Edge47.
     static member inline edge74 (b:Box) : Line3D =
@@ -2279,8 +2309,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge51 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX, b.OriginY + b.XaxisY, b.OriginZ + b.XaxisZ)
+        let p1x = b.OriginX + b.XaxisX
+        let p1y = b.OriginY + b.XaxisY
+        let p1z = b.OriginZ + b.XaxisZ
+        Line3D(p1x + b.ZaxisX, p1y + b.ZaxisY, p1z + b.ZaxisZ, p1x, p1y, p1z)
 
     /// Returns the Z-aligned edge from point 5 to 1. This is the reverse of Edge15.
     static member inline edge51 (b:Box) : Line3D =
@@ -2298,8 +2330,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge62 : Line3D =
-        Line3D(b.OriginX + b.XaxisX + b.YaxisX + b.ZaxisX, b.OriginY + b.XaxisY + b.YaxisY + b.ZaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.XaxisX + b.YaxisX, b.OriginY + b.XaxisY + b.YaxisY, b.OriginZ + b.XaxisZ + b.YaxisZ)
+        let p2x = b.OriginX + b.XaxisX + b.YaxisX
+        let p2y = b.OriginY + b.XaxisY + b.YaxisY
+        let p2z = b.OriginZ + b.XaxisZ + b.YaxisZ
+        Line3D(p2x + b.ZaxisX, p2y + b.ZaxisY, p2z + b.ZaxisZ, p2x, p2y, p2z)
 
     /// Returns the Z-aligned edge from point 6 to 2. This is the reverse of Edge26.
     static member inline edge62 (b:Box) : Line3D =
@@ -2317,8 +2351,10 @@ type Box =
     /// </code>
     /// </summary>
     member inline b.Edge73 : Line3D =
-        Line3D(b.OriginX + b.YaxisX + b.ZaxisX, b.OriginY + b.YaxisY + b.ZaxisY, b.OriginZ + b.YaxisZ + b.ZaxisZ,
-               b.OriginX + b.YaxisX, b.OriginY + b.YaxisY, b.OriginZ + b.YaxisZ)
+        let p3x = b.OriginX + b.YaxisX
+        let p3y = b.OriginY + b.YaxisY
+        let p3z = b.OriginZ + b.YaxisZ
+        Line3D(p3x + b.ZaxisX, p3y + b.ZaxisY, p3z + b.ZaxisZ, p3x, p3y, p3z)
 
     /// Returns the Z-aligned edge from point 7 to 3. This is the reverse of Edge37.
     static member inline edge73 (b:Box) : Line3D =

--- a/Src/FreeBox.fs
+++ b/Src/FreeBox.fs
@@ -564,6 +564,102 @@ type FreeBox private (pts:Pnt[]) =
     static member inline edge47 (b:FreeBox) :Line3D =
         b.Edge47
 
+    /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
+    member b.Edge10 :Line3D =
+        b.Edge01.Reversed
+
+    /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
+    static member inline edge10 (b:FreeBox) :Line3D =
+        b.Edge10
+
+    /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
+    member b.Edge21 :Line3D =
+        b.Edge12.Reversed
+
+    /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
+    static member inline edge21 (b:FreeBox) :Line3D =
+        b.Edge21
+
+    /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
+    member b.Edge23 :Line3D =
+        b.Edge32.Reversed
+
+    /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
+    static member inline edge23 (b:FreeBox) :Line3D =
+        b.Edge23
+
+    /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
+    member b.Edge30 :Line3D =
+        b.Edge03.Reversed
+
+    /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
+    static member inline edge30 (b:FreeBox) :Line3D =
+        b.Edge30
+
+    /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
+    member b.Edge40 :Line3D =
+        b.Edge04.Reversed
+
+    /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
+    static member inline edge40 (b:FreeBox) :Line3D =
+        b.Edge40
+
+    /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
+    member b.Edge51 :Line3D =
+        b.Edge15.Reversed
+
+    /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
+    static member inline edge51 (b:FreeBox) :Line3D =
+        b.Edge51
+
+    /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
+    member b.Edge62 :Line3D =
+        b.Edge26.Reversed
+
+    /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
+    static member inline edge62 (b:FreeBox) :Line3D =
+        b.Edge62
+
+    /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
+    member b.Edge73 :Line3D =
+        b.Edge37.Reversed
+
+    /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
+    static member inline edge73 (b:FreeBox) :Line3D =
+        b.Edge73
+
+    /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
+    member b.Edge54 :Line3D =
+        b.Edge45.Reversed
+
+    /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
+    static member inline edge54 (b:FreeBox) :Line3D =
+        b.Edge54
+
+    /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
+    member b.Edge65 :Line3D =
+        b.Edge56.Reversed
+
+    /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
+    static member inline edge65 (b:FreeBox) :Line3D =
+        b.Edge65
+
+    /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
+    member b.Edge67 :Line3D =
+        b.Edge76.Reversed
+
+    /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
+    static member inline edge67 (b:FreeBox) :Line3D =
+        b.Edge67
+
+    /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
+    member b.Edge74 :Line3D =
+        b.Edge47.Reversed
+
+    /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
+    static member inline edge74 (b:FreeBox) :Line3D =
+        b.Edge74
+
 
 
     // these members don't make sense for a FreeBox:
@@ -620,42 +716,6 @@ type FreeBox private (pts:Pnt[]) =
 
 
     // #region Obsolete
-
-    [<Obsolete("Use .Edge01 instead.")>]
-    member b.Edge0 :Line3D = b.Edge01
-
-    [<Obsolete("Use .Edge12 instead.")>]
-    member b.Edge1 :Line3D = b.Edge12
-
-    [<Obsolete("Use .Edge32 instead.")>]
-    member b.Edge2 :Line3D = b.Edge32
-
-    [<Obsolete("Use .Edge03 instead.")>]
-    member b.Edge3 :Line3D = b.Edge03
-
-    [<Obsolete("Use .Edge45 instead.")>]
-    member b.Edge4 :Line3D = b.Edge45
-
-    [<Obsolete("Use .Edge56 instead.")>]
-    member b.Edge5 :Line3D = b.Edge56
-
-    [<Obsolete("Use .Edge76 instead.")>]
-    member b.Edge6 :Line3D = b.Edge76
-
-    [<Obsolete("Use .Edge47 instead.")>]
-    member b.Edge7 :Line3D = b.Edge47
-
-    [<Obsolete("Use .Edge04 instead.")>]
-    member b.Edge8 :Line3D = b.Edge04
-
-    [<Obsolete("Use .Edge15 instead.")>]
-    member b.Edge9 :Line3D = b.Edge15
-
-    [<Obsolete("Use .Edge26 instead.")>]
-    member b.Edge10 :Line3D = b.Edge26
-
-    [<Obsolete("Use .Edge37 instead.")>]
-    member b.Edge11 :Line3D = b.Edge37
 
     // #endregion
 

--- a/Src/FreeBox.fs
+++ b/Src/FreeBox.fs
@@ -566,7 +566,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
     member b.Edge10 :Line3D =
-        b.Edge01.Reversed
+        Line3D(pts.[1].X, pts.[1].Y, pts.[1].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
 
     /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
     static member inline edge10 (b:FreeBox) :Line3D =
@@ -574,7 +574,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
     member b.Edge21 :Line3D =
-        b.Edge12.Reversed
+        Line3D(pts.[2].X, pts.[2].Y, pts.[2].Z, pts.[1].X, pts.[1].Y, pts.[1].Z)
 
     /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
     static member inline edge21 (b:FreeBox) :Line3D =
@@ -582,7 +582,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
     member b.Edge23 :Line3D =
-        b.Edge32.Reversed
+        Line3D(pts.[2].X, pts.[2].Y, pts.[2].Z, pts.[3].X, pts.[3].Y, pts.[3].Z)
 
     /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
     static member inline edge23 (b:FreeBox) :Line3D =
@@ -590,7 +590,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
     member b.Edge30 :Line3D =
-        b.Edge03.Reversed
+        Line3D(pts.[3].X, pts.[3].Y, pts.[3].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
 
     /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
     static member inline edge30 (b:FreeBox) :Line3D =
@@ -598,7 +598,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
     member b.Edge40 :Line3D =
-        b.Edge04.Reversed
+        Line3D(pts.[4].X, pts.[4].Y, pts.[4].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
 
     /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
     static member inline edge40 (b:FreeBox) :Line3D =
@@ -606,7 +606,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
     member b.Edge51 :Line3D =
-        b.Edge15.Reversed
+        Line3D(pts.[5].X, pts.[5].Y, pts.[5].Z, pts.[1].X, pts.[1].Y, pts.[1].Z)
 
     /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
     static member inline edge51 (b:FreeBox) :Line3D =
@@ -614,7 +614,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
     member b.Edge62 :Line3D =
-        b.Edge26.Reversed
+        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[2].X, pts.[2].Y, pts.[2].Z)
 
     /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
     static member inline edge62 (b:FreeBox) :Line3D =
@@ -622,7 +622,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
     member b.Edge73 :Line3D =
-        b.Edge37.Reversed
+        Line3D(pts.[7].X, pts.[7].Y, pts.[7].Z, pts.[3].X, pts.[3].Y, pts.[3].Z)
 
     /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
     static member inline edge73 (b:FreeBox) :Line3D =
@@ -630,7 +630,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
     member b.Edge54 :Line3D =
-        b.Edge45.Reversed
+        Line3D(pts.[5].X, pts.[5].Y, pts.[5].Z, pts.[4].X, pts.[4].Y, pts.[4].Z)
 
     /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
     static member inline edge54 (b:FreeBox) :Line3D =
@@ -638,7 +638,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
     member b.Edge65 :Line3D =
-        b.Edge56.Reversed
+        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[5].X, pts.[5].Y, pts.[5].Z)
 
     /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
     static member inline edge65 (b:FreeBox) :Line3D =
@@ -646,7 +646,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
     member b.Edge67 :Line3D =
-        b.Edge76.Reversed
+        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[7].X, pts.[7].Y, pts.[7].Z)
 
     /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
     static member inline edge67 (b:FreeBox) :Line3D =
@@ -654,7 +654,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
     member b.Edge74 :Line3D =
-        b.Edge47.Reversed
+        Line3D(pts.[7].X, pts.[7].Y, pts.[7].Z, pts.[4].X, pts.[4].Y, pts.[4].Z)
 
     /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
     static member inline edge74 (b:FreeBox) :Line3D =

--- a/Src/FreeBox.fs
+++ b/Src/FreeBox.fs
@@ -470,7 +470,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 0 and point 1.
     member b.Edge01 :Line3D =
-        Line3D(pts.[0].X, pts.[0].Y, pts.[0].Z, pts.[1].X, pts.[1].Y, pts.[1].Z)
+        Line3D(pts.[0], pts.[1])
 
     /// Returns the edge between point 0 and point 1.
     static member inline edge01 (b:FreeBox) :Line3D =
@@ -478,7 +478,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 1 and point 2.
     member b.Edge12 :Line3D =
-        Line3D(pts.[1].X, pts.[1].Y, pts.[1].Z, pts.[2].X, pts.[2].Y, pts.[2].Z)
+        Line3D(pts.[1], pts.[2])
 
     /// Returns the edge between point 1 and point 2.
     static member inline edge12 (b:FreeBox) :Line3D =
@@ -486,7 +486,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 3 and point 2.
     member b.Edge32 :Line3D =
-        Line3D(pts.[3].X, pts.[3].Y, pts.[3].Z, pts.[2].X, pts.[2].Y, pts.[2].Z)
+        Line3D(pts.[3], pts.[2])
 
     /// Returns the edge between point 3 and point 2.
     static member inline edge32 (b:FreeBox) :Line3D =
@@ -494,7 +494,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 0 and point 3.
     member b.Edge03 :Line3D =
-        Line3D(pts.[0].X, pts.[0].Y, pts.[0].Z, pts.[3].X, pts.[3].Y, pts.[3].Z)
+        Line3D(pts.[0], pts.[3])
 
     /// Returns the edge between point 0 and point 3.
     static member inline edge03 (b:FreeBox) :Line3D =
@@ -502,7 +502,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 0 and point 4.
     member b.Edge04 :Line3D =
-        Line3D(pts.[0].X, pts.[0].Y, pts.[0].Z, pts.[4].X, pts.[4].Y, pts.[4].Z)
+        Line3D(pts.[0], pts.[4])
 
     /// Returns the edge between point 0 and point 4.
     static member inline edge04 (b:FreeBox) :Line3D =
@@ -510,7 +510,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 1 and point 5.
     member b.Edge15 :Line3D =
-        Line3D(pts.[1].X, pts.[1].Y, pts.[1].Z, pts.[5].X, pts.[5].Y, pts.[5].Z)
+        Line3D(pts.[1], pts.[5])
 
     /// Returns the edge between point 1 and point 5.
     static member inline edge15 (b:FreeBox) :Line3D =
@@ -518,7 +518,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 2 and point 6.
     member b.Edge26 :Line3D =
-        Line3D(pts.[2].X, pts.[2].Y, pts.[2].Z, pts.[6].X, pts.[6].Y, pts.[6].Z)
+        Line3D(pts.[2], pts.[6])
 
     /// Returns the edge between point 2 and point 6.
     static member inline edge26 (b:FreeBox) :Line3D =
@@ -526,7 +526,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 3 and point 7.
     member b.Edge37 :Line3D =
-        Line3D(pts.[3].X, pts.[3].Y, pts.[3].Z, pts.[7].X, pts.[7].Y, pts.[7].Z)
+        Line3D(pts.[3], pts.[7])
 
     /// Returns the edge between point 3 and point 7.
     static member inline edge37 (b:FreeBox) :Line3D =
@@ -534,7 +534,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 4 and point 5.
     member b.Edge45 :Line3D =
-        Line3D(pts.[4].X, pts.[4].Y, pts.[4].Z, pts.[5].X, pts.[5].Y, pts.[5].Z)
+        Line3D(pts.[4], pts.[5])
 
     /// Returns the edge between point 4 and point 5.
     static member inline edge45 (b:FreeBox) :Line3D =
@@ -542,7 +542,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 5 and point 6.
     member b.Edge56 :Line3D =
-        Line3D(pts.[5].X, pts.[5].Y, pts.[5].Z, pts.[6].X, pts.[6].Y, pts.[6].Z)
+        Line3D(pts.[5], pts.[6])
 
     /// Returns the edge between point 5 and point 6.
     static member inline edge56 (b:FreeBox) :Line3D =
@@ -550,7 +550,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 7 and point 6.
     member b.Edge76 :Line3D =
-        Line3D(pts.[7].X, pts.[7].Y, pts.[7].Z, pts.[6].X, pts.[6].Y, pts.[6].Z)
+        Line3D(pts.[7], pts.[6])
 
     /// Returns the edge between point 7 and point 6.
     static member inline edge76 (b:FreeBox) :Line3D =
@@ -558,7 +558,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 4 and point 7.
     member b.Edge47 :Line3D =
-        Line3D(pts.[4].X, pts.[4].Y, pts.[4].Z, pts.[7].X, pts.[7].Y, pts.[7].Z)
+        Line3D(pts.[4], pts.[7])
 
     /// Returns the edge between point 4 and point 7.
     static member inline edge47 (b:FreeBox) :Line3D =
@@ -566,7 +566,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
     member b.Edge10 :Line3D =
-        Line3D(pts.[1].X, pts.[1].Y, pts.[1].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
+        Line3D(pts.[1], pts.[0])
 
     /// Returns the edge between point 1 and point 0. This is the reverse of Edge01.
     static member inline edge10 (b:FreeBox) :Line3D =
@@ -574,7 +574,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
     member b.Edge21 :Line3D =
-        Line3D(pts.[2].X, pts.[2].Y, pts.[2].Z, pts.[1].X, pts.[1].Y, pts.[1].Z)
+        Line3D(pts.[2], pts.[1])
 
     /// Returns the edge between point 2 and point 1. This is the reverse of Edge12.
     static member inline edge21 (b:FreeBox) :Line3D =
@@ -582,7 +582,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
     member b.Edge23 :Line3D =
-        Line3D(pts.[2].X, pts.[2].Y, pts.[2].Z, pts.[3].X, pts.[3].Y, pts.[3].Z)
+        Line3D(pts.[2], pts.[3])
 
     /// Returns the edge between point 2 and point 3. This is the reverse of Edge32.
     static member inline edge23 (b:FreeBox) :Line3D =
@@ -590,7 +590,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
     member b.Edge30 :Line3D =
-        Line3D(pts.[3].X, pts.[3].Y, pts.[3].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
+        Line3D(pts.[3], pts.[0])
 
     /// Returns the edge between point 3 and point 0. This is the reverse of Edge03.
     static member inline edge30 (b:FreeBox) :Line3D =
@@ -598,7 +598,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
     member b.Edge40 :Line3D =
-        Line3D(pts.[4].X, pts.[4].Y, pts.[4].Z, pts.[0].X, pts.[0].Y, pts.[0].Z)
+        Line3D(pts.[4], pts.[0])
 
     /// Returns the edge between point 4 and point 0. This is the reverse of Edge04.
     static member inline edge40 (b:FreeBox) :Line3D =
@@ -606,7 +606,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
     member b.Edge51 :Line3D =
-        Line3D(pts.[5].X, pts.[5].Y, pts.[5].Z, pts.[1].X, pts.[1].Y, pts.[1].Z)
+        Line3D(pts.[5], pts.[1])
 
     /// Returns the edge between point 5 and point 1. This is the reverse of Edge15.
     static member inline edge51 (b:FreeBox) :Line3D =
@@ -614,7 +614,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
     member b.Edge62 :Line3D =
-        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[2].X, pts.[2].Y, pts.[2].Z)
+        Line3D(pts.[6], pts.[2])
 
     /// Returns the edge between point 6 and point 2. This is the reverse of Edge26.
     static member inline edge62 (b:FreeBox) :Line3D =
@@ -622,7 +622,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
     member b.Edge73 :Line3D =
-        Line3D(pts.[7].X, pts.[7].Y, pts.[7].Z, pts.[3].X, pts.[3].Y, pts.[3].Z)
+        Line3D(pts.[7], pts.[3])
 
     /// Returns the edge between point 7 and point 3. This is the reverse of Edge37.
     static member inline edge73 (b:FreeBox) :Line3D =
@@ -630,7 +630,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
     member b.Edge54 :Line3D =
-        Line3D(pts.[5].X, pts.[5].Y, pts.[5].Z, pts.[4].X, pts.[4].Y, pts.[4].Z)
+        Line3D(pts.[5], pts.[4])
 
     /// Returns the edge between point 5 and point 4. This is the reverse of Edge45.
     static member inline edge54 (b:FreeBox) :Line3D =
@@ -638,7 +638,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
     member b.Edge65 :Line3D =
-        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[5].X, pts.[5].Y, pts.[5].Z)
+        Line3D(pts.[6], pts.[5])
 
     /// Returns the edge between point 6 and point 5. This is the reverse of Edge56.
     static member inline edge65 (b:FreeBox) :Line3D =
@@ -646,7 +646,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
     member b.Edge67 :Line3D =
-        Line3D(pts.[6].X, pts.[6].Y, pts.[6].Z, pts.[7].X, pts.[7].Y, pts.[7].Z)
+        Line3D(pts.[6], pts.[7])
 
     /// Returns the edge between point 6 and point 7. This is the reverse of Edge76.
     static member inline edge67 (b:FreeBox) :Line3D =
@@ -654,7 +654,7 @@ type FreeBox private (pts:Pnt[]) =
 
     /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
     member b.Edge74 :Line3D =
-        Line3D(pts.[7].X, pts.[7].Y, pts.[7].Z, pts.[4].X, pts.[4].Y, pts.[4].Z)
+        Line3D(pts.[7], pts.[4])
 
     /// Returns the edge between point 7 and point 4. This is the reverse of Edge47.
     static member inline edge74 (b:FreeBox) :Line3D =

--- a/Src/Rect2D.fs
+++ b/Src/Rect2D.fs
@@ -1857,7 +1857,7 @@ type Rect2D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge10 : Line2D =
-        r.Edge01.Reversed
+        Line2D(r.OriginX + r.XaxisX, r.OriginY + r.XaxisY, r.OriginX, r.OriginY)
 
     /// Returns edge 1-0 of the 2D rectangle. This is the reverse of Edge01.
     static member inline edge10 (r:Rect2D) : Line2D =
@@ -1880,7 +1880,9 @@ type Rect2D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge21 : Line2D =
-        r.Edge12.Reversed
+        let sx = r.OriginX + r.XaxisX
+        let sy = r.OriginY + r.XaxisY
+        Line2D(sx + r.YaxisX, sy + r.YaxisY, sx, sy)
 
     /// Returns edge 2-1 of the 2D rectangle. This is the reverse of Edge12.
     static member inline edge21 (r:Rect2D) : Line2D =
@@ -1903,7 +1905,9 @@ type Rect2D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge32 : Line2D =
-        r.Edge23.Reversed
+        let p3x = r.OriginX + r.YaxisX
+        let p3y = r.OriginY + r.YaxisY
+        Line2D(p3x, p3y, p3x + r.XaxisX, p3y + r.XaxisY)
 
     /// Returns edge 3-2 of the 2D rectangle. This is the reverse of Edge23.
     static member inline edge32 (r:Rect2D) : Line2D =
@@ -1926,7 +1930,7 @@ type Rect2D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge03 : Line2D =
-        r.Edge30.Reversed
+        Line2D(r.OriginX, r.OriginY, r.OriginX + r.YaxisX, r.OriginY + r.YaxisY)
 
     /// Returns edge 0-3 of the 2D rectangle. This is the reverse of Edge30.
     static member inline edge03 (r:Rect2D) : Line2D =

--- a/Src/Rect2D.fs
+++ b/Src/Rect2D.fs
@@ -1840,6 +1840,98 @@ type Rect2D =
     static member inline edge30 (r:Rect2D) : Line2D =
         r.Edge30
 
+    /// <summary>Returns a 2D line from point 1 to 0 of the 2D rectangle. This is the reverse of Edge01.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge10 : Line2D =
+        r.Edge01.Reversed
+
+    /// Returns edge 1-0 of the 2D rectangle. This is the reverse of Edge01.
+    static member inline edge10 (r:Rect2D) : Line2D =
+        r.Edge10
+
+    /// <summary>Returns a 2D line from point 2 to 1 of the 2D rectangle. This is the reverse of Edge12.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge21 : Line2D =
+        r.Edge12.Reversed
+
+    /// Returns edge 2-1 of the 2D rectangle. This is the reverse of Edge12.
+    static member inline edge21 (r:Rect2D) : Line2D =
+        r.Edge21
+
+    /// <summary>Returns a 2D line from point 3 to 2 of the 2D rectangle. This is the reverse of Edge23.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge32 : Line2D =
+        r.Edge23.Reversed
+
+    /// Returns edge 3-2 of the 2D rectangle. This is the reverse of Edge23.
+    static member inline edge32 (r:Rect2D) : Line2D =
+        r.Edge32
+
+    /// <summary>Returns a 2D line from point 0 to 3 of the 2D rectangle. This is the reverse of Edge30.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge03 : Line2D =
+        r.Edge30.Reversed
+
+    /// Returns edge 0-3 of the 2D rectangle. This is the reverse of Edge30.
+    static member inline edge03 (r:Rect2D) : Line2D =
+        r.Edge03
+
     /// <summary>Returns the local X side as the 2D line from point 0 to 1 of the 2D rectangle.
     /// <code>
     ///   local

--- a/Src/Rect3D.fs
+++ b/Src/Rect3D.fs
@@ -900,6 +900,98 @@ type Rect3D =
     static member inline edge30 (r:Rect3D) : Line3D =
         r.Edge30
 
+    /// <summary>Returns a 3D line from point 1 to 0 of the 3D-rectangle. This is the reverse of Edge01.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge10 : Line3D =
+        r.Edge01.Reversed
+
+    /// Returns a 3D line from point 1 to 0 of the rectangle. This is the reverse of Edge01.
+    static member inline edge10 (r:Rect3D) : Line3D =
+        r.Edge10
+
+    /// <summary>Returns a 3D line from point 2 to 1 of the 3D-rectangle. This is the reverse of Edge12.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge21 : Line3D =
+        r.Edge12.Reversed
+
+    /// Returns a 3D line from point 2 to 1 of the rectangle. This is the reverse of Edge12.
+    static member inline edge21 (r:Rect3D) : Line3D =
+        r.Edge21
+
+    /// <summary>Returns a 3D line from point 3 to 2 of the 3D-rectangle. This is the reverse of Edge23.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge32 : Line3D =
+        r.Edge23.Reversed
+
+    /// Returns a 3D line from point 3 to 2 of the rectangle. This is the reverse of Edge23.
+    static member inline edge32 (r:Rect3D) : Line3D =
+        r.Edge32
+
+    /// <summary>Returns a 3D line from point 0 to 3 of the 3D-rectangle. This is the reverse of Edge30.
+    /// <code>
+    ///   local
+    ///   Y-axis
+    ///   ^
+    ///   |
+    ///   |             2
+    /// 3 +------------+
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |
+    ///   |            |       local
+    ///   +------------+-----> X-axis
+    ///  0-Origin       1
+    /// </code></summary>
+    member inline r.Edge03 : Line3D =
+        r.Edge30.Reversed
+
+    /// Returns a 3D line from point 0 to 3 of the rectangle. This is the reverse of Edge30.
+    static member inline edge03 (r:Rect3D) : Line3D =
+        r.Edge03
+
     /// <summary>Returns the local X side as the 3D line from point 0 to 1 of the 3D-rectangle.
     /// <code>
     ///   local

--- a/Src/Rect3D.fs
+++ b/Src/Rect3D.fs
@@ -917,7 +917,7 @@ type Rect3D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge10 : Line3D =
-        r.Edge01.Reversed
+        Line3D(r.OriginX + r.XaxisX, r.OriginY + r.XaxisY, r.OriginZ + r.XaxisZ, r.OriginX, r.OriginY, r.OriginZ)
 
     /// Returns a 3D line from point 1 to 0 of the rectangle. This is the reverse of Edge01.
     static member inline edge10 (r:Rect3D) : Line3D =
@@ -940,7 +940,10 @@ type Rect3D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge21 : Line3D =
-        r.Edge12.Reversed
+        let sx = r.OriginX + r.XaxisX
+        let sy = r.OriginY + r.XaxisY
+        let sz = r.OriginZ + r.XaxisZ
+        Line3D(sx + r.YaxisX, sy + r.YaxisY, sz + r.YaxisZ, sx, sy, sz)
 
     /// Returns a 3D line from point 2 to 1 of the rectangle. This is the reverse of Edge12.
     static member inline edge21 (r:Rect3D) : Line3D =
@@ -963,7 +966,10 @@ type Rect3D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge32 : Line3D =
-        r.Edge23.Reversed
+        let p3x = r.OriginX + r.YaxisX
+        let p3y = r.OriginY + r.YaxisY
+        let p3z = r.OriginZ + r.YaxisZ
+        Line3D(p3x, p3y, p3z, p3x + r.XaxisX, p3y + r.XaxisY, p3z + r.XaxisZ)
 
     /// Returns a 3D line from point 3 to 2 of the rectangle. This is the reverse of Edge23.
     static member inline edge32 (r:Rect3D) : Line3D =
@@ -986,7 +992,7 @@ type Rect3D =
     ///  0-Origin       1
     /// </code></summary>
     member inline r.Edge03 : Line3D =
-        r.Edge30.Reversed
+        Line3D(r.OriginX, r.OriginY, r.OriginZ, r.OriginX + r.YaxisX, r.OriginY + r.YaxisY, r.OriginZ + r.YaxisZ)
 
     /// Returns a 3D line from point 0 to 3 of the rectangle. This is the reverse of Edge30.
     static member inline edge03 (r:Rect3D) : Line3D =

--- a/Test/TestBBox.fs
+++ b/Test/TestBBox.fs
@@ -697,6 +697,23 @@ let tests =
                 Expect.isTrue (eqPnt edge.From box.Pt3) "From should be Pt3"
                 Expect.isTrue (eqPnt edge.To box.Pt7) "To should be Pt7"
             }
+
+            test "BBox reverse edges are the reverse of the forward edges" {
+                let box = BBox.create(Pnt(0., 0., 0.), Pnt(10., 5., 3.))
+                let isReverseOf (fwd:Line3D) (rev:Line3D) = eqPnt fwd.From rev.To && eqPnt fwd.To rev.From
+                Expect.isTrue (isReverseOf box.Edge01 box.Edge10) "Edge10 should be the reverse of Edge01"
+                Expect.isTrue (isReverseOf box.Edge12 box.Edge21) "Edge21 should be the reverse of Edge12"
+                Expect.isTrue (isReverseOf box.Edge32 box.Edge23) "Edge23 should be the reverse of Edge32"
+                Expect.isTrue (isReverseOf box.Edge03 box.Edge30) "Edge30 should be the reverse of Edge03"
+                Expect.isTrue (isReverseOf box.Edge04 box.Edge40) "Edge40 should be the reverse of Edge04"
+                Expect.isTrue (isReverseOf box.Edge15 box.Edge51) "Edge51 should be the reverse of Edge15"
+                Expect.isTrue (isReverseOf box.Edge26 box.Edge62) "Edge62 should be the reverse of Edge26"
+                Expect.isTrue (isReverseOf box.Edge37 box.Edge73) "Edge73 should be the reverse of Edge37"
+                Expect.isTrue (isReverseOf box.Edge45 box.Edge54) "Edge54 should be the reverse of Edge45"
+                Expect.isTrue (isReverseOf box.Edge56 box.Edge65) "Edge65 should be the reverse of Edge56"
+                Expect.isTrue (isReverseOf box.Edge76 box.Edge67) "Edge67 should be the reverse of Edge76"
+                Expect.isTrue (isReverseOf box.Edge47 box.Edge74) "Edge74 should be the reverse of Edge47"
+            }
         ]
 
         testList "Validation Methods" [

--- a/Test/TestBRect.fs
+++ b/Test/TestBRect.fs
@@ -550,6 +550,18 @@ let tests =
                 Expect.isTrue (eqPt r.Edge30.From r.Pt3) "Edge30 should start at Pt3"
                 Expect.isTrue (eqPt r.Edge30.To r.Pt0) "Edge30 should end at Pt0"
             }
+
+            test "Reverse edges are correct" {
+                let r = BRect.create(Pt(1., 2.), Pt(5., 7.))
+                Expect.isTrue (eqPt r.Edge10.From r.Pt1) "Edge10 should start at Pt1"
+                Expect.isTrue (eqPt r.Edge10.To r.Pt0) "Edge10 should end at Pt0"
+                Expect.isTrue (eqPt r.Edge21.From r.Pt2) "Edge21 should start at Pt2"
+                Expect.isTrue (eqPt r.Edge21.To r.Pt1) "Edge21 should end at Pt1"
+                Expect.isTrue (eqPt r.Edge32.From r.Pt3) "Edge32 should start at Pt3"
+                Expect.isTrue (eqPt r.Edge32.To r.Pt2) "Edge32 should end at Pt2"
+                Expect.isTrue (eqPt r.Edge03.From r.Pt0) "Edge03 should start at Pt0"
+                Expect.isTrue (eqPt r.Edge03.To r.Pt3) "Edge03 should end at Pt3"
+            }
         ]
 
         testList "Equality" [

--- a/Test/TestBox.fs
+++ b/Test/TestBox.fs
@@ -559,6 +559,23 @@ let tests =
                 Expect.isTrue (eqLine box.Edge47 bbox.Edge47) "Edge47 should match"
             }
 
+            test "Box reverse edges are the reverse of the forward edges" {
+                let box = Box.createUncheckedVec(Pnt(1., 2., 3.), Vec(10., 0., 0.), Vec(0., 5., 0.), Vec(0., 0., 3.))
+                let isReverseOf (fwd:Line3D) (rev:Line3D) = eqPnt fwd.From rev.To && eqPnt fwd.To rev.From
+                Expect.isTrue (isReverseOf box.Edge01 box.Edge10) "Edge10 should be the reverse of Edge01"
+                Expect.isTrue (isReverseOf box.Edge12 box.Edge21) "Edge21 should be the reverse of Edge12"
+                Expect.isTrue (isReverseOf box.Edge32 box.Edge23) "Edge23 should be the reverse of Edge32"
+                Expect.isTrue (isReverseOf box.Edge03 box.Edge30) "Edge30 should be the reverse of Edge03"
+                Expect.isTrue (isReverseOf box.Edge04 box.Edge40) "Edge40 should be the reverse of Edge04"
+                Expect.isTrue (isReverseOf box.Edge15 box.Edge51) "Edge51 should be the reverse of Edge15"
+                Expect.isTrue (isReverseOf box.Edge26 box.Edge62) "Edge62 should be the reverse of Edge26"
+                Expect.isTrue (isReverseOf box.Edge37 box.Edge73) "Edge73 should be the reverse of Edge37"
+                Expect.isTrue (isReverseOf box.Edge45 box.Edge54) "Edge54 should be the reverse of Edge45"
+                Expect.isTrue (isReverseOf box.Edge56 box.Edge65) "Edge65 should be the reverse of Edge56"
+                Expect.isTrue (isReverseOf box.Edge76 box.Edge67) "Edge67 should be the reverse of Edge76"
+                Expect.isTrue (isReverseOf box.Edge47 box.Edge74) "Edge74 should be the reverse of Edge47"
+            }
+
             test "Box edges equal BBox edges via GetEdge after conversion" {
                 // The 12 edges must also coincide index-by-index through GetEdge / Edges.
                 let box = Box.createUncheckedVec(Pnt(-4., 1., -2.), Vec(7., 0., 0.), Vec(0., 9., 0.), Vec(0., 0., 6.))

--- a/Test/TestFreeBox.fs
+++ b/Test/TestFreeBox.fs
@@ -106,6 +106,29 @@ let tests =
             }
         ]
 
+        testList "Edges" [
+            test "Reverse edges are the reverse of the forward edges" {
+                let pts = [|
+                    Pnt(0., 0., 0.); Pnt(10., 0., 0.); Pnt(10., 5., 0.); Pnt(0., 5., 0.)
+                    Pnt(0., 0., 3.); Pnt(10., 0., 3.); Pnt(10., 5., 3.); Pnt(0., 5., 3.)
+                |]
+                let box = FreeBox.createFromEightPoints pts
+                let isReverseOf (fwd:Line3D) (rev:Line3D) = eqPnt fwd.From rev.To && eqPnt fwd.To rev.From
+                Expect.isTrue (isReverseOf box.Edge01 box.Edge10) "Edge10 should be the reverse of Edge01"
+                Expect.isTrue (isReverseOf box.Edge12 box.Edge21) "Edge21 should be the reverse of Edge12"
+                Expect.isTrue (isReverseOf box.Edge32 box.Edge23) "Edge23 should be the reverse of Edge32"
+                Expect.isTrue (isReverseOf box.Edge03 box.Edge30) "Edge30 should be the reverse of Edge03"
+                Expect.isTrue (isReverseOf box.Edge04 box.Edge40) "Edge40 should be the reverse of Edge04"
+                Expect.isTrue (isReverseOf box.Edge15 box.Edge51) "Edge51 should be the reverse of Edge15"
+                Expect.isTrue (isReverseOf box.Edge26 box.Edge62) "Edge62 should be the reverse of Edge26"
+                Expect.isTrue (isReverseOf box.Edge37 box.Edge73) "Edge73 should be the reverse of Edge37"
+                Expect.isTrue (isReverseOf box.Edge45 box.Edge54) "Edge54 should be the reverse of Edge45"
+                Expect.isTrue (isReverseOf box.Edge56 box.Edge65) "Edge65 should be the reverse of Edge56"
+                Expect.isTrue (isReverseOf box.Edge76 box.Edge67) "Edge67 should be the reverse of Edge76"
+                Expect.isTrue (isReverseOf box.Edge47 box.Edge74) "Edge74 should be the reverse of Edge47"
+            }
+        ]
+
         testList "Transformation Methods" [
             test "Scale from world origin" {
                 let pts = [|

--- a/Test/TestRect2D.fs
+++ b/Test/TestRect2D.fs
@@ -168,6 +168,12 @@ let tests =
                 "Edge23" |> Expect.isTrue (eqLine rr.Edge23 p2 p3)
                 "Edge30" |> Expect.isTrue (eqLine rr.Edge30 p3 p0)
             }
+            test "Edge10..Edge03 (reverse edges)" {
+                "Edge10" |> Expect.isTrue (eqLine rr.Edge10 p1 p0)
+                "Edge21" |> Expect.isTrue (eqLine rr.Edge21 p2 p1)
+                "Edge32" |> Expect.isTrue (eqLine rr.Edge32 p3 p2)
+                "Edge03" |> Expect.isTrue (eqLine rr.Edge03 p0 p3)
+            }
             test "EdgeX / EdgeY" {
                 "EdgeX is 0->1" |> Expect.isTrue (eqLine rr.EdgeX p0 p1)
                 "EdgeY is 0->3" |> Expect.isTrue (eqLine rr.EdgeY p0 p3)

--- a/Test/TestRect3D.fs
+++ b/Test/TestRect3D.fs
@@ -10,6 +10,7 @@ open Expecto
 
 let inline eq a b = Pnt.dist a b < 1e-9
 let inline equ a (b:float) = abs(a-b) < 1e-9
+let inline eqLine (ln:Line3D) (a:Pnt) (b:Pnt) = eq ln.From a && eq ln.To b
 
 
 let o = Pnt.Origin
@@ -19,6 +20,18 @@ let rect = Rect3D.createFromVectors(o,x,y)
 
 let tests =
     testList "Rect3D" [
+
+        test "Rect3D Edge01..Edge30 and reverse edges" {
+            let p0, p1, p2, p3 = rect.Pt0, rect.Pt1, rect.Pt2, rect.Pt3
+            "Edge01" |> Expect.isTrue (eqLine rect.Edge01 p0 p1)
+            "Edge12" |> Expect.isTrue (eqLine rect.Edge12 p1 p2)
+            "Edge23" |> Expect.isTrue (eqLine rect.Edge23 p2 p3)
+            "Edge30" |> Expect.isTrue (eqLine rect.Edge30 p3 p0)
+            "Edge10" |> Expect.isTrue (eqLine rect.Edge10 p1 p0)
+            "Edge21" |> Expect.isTrue (eqLine rect.Edge21 p2 p1)
+            "Edge32" |> Expect.isTrue (eqLine rect.Edge32 p3 p2)
+            "Edge03" |> Expect.isTrue (eqLine rect.Edge03 p0 p3)
+        }
 
         test "Rect3D.grid" {
         let grid = Rect3D.grid (rect, 2, 2)


### PR DESCRIPTION
Every named edge (Edge01, Edge32, ...) now has a matching reverse
accessor (Edge10, Edge23, ...) with an instance and static member, so
edges can be addressed in either direction.

This required removing the obsolete numeric Edge0-Edge11 aliases on
Box and FreeBox, since the old alias for index 10 collided with the
new reverse-of-Edge01 member of the same name.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MV7hXkviAeLJnqRcEWkXkg