### PR TITLE
Rename `set*` methods to `with*` for immutable operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added `with`-prefixed replacements for all members that had a `set` prefix but returned a new value instead of mutating: `Line2D.withStart/withFrom/withEnd/withTo`, `Line3D.withStart/withFrom/withEnd/withTo`, `PPlane.withOrigin/withOriginX/withOriginY/withOriginZ`, and `Quaternion.WithAngleInRadians/WithAngleInDegrees` (plus the static `withAngleInRadians`/`withAngleInDegrees`).
 - `Rect2D`, `Rect3D`, `BRect`, `Box`, `BBox`, and `FreeBox` now have a reverse-direction instance and static member for every named edge (e.g. `Edge10` next to `Edge01`, `Edge23` next to `Edge32`), so every edge can be addressed in either direction.
 - Added `Line2D.pointAtDistanceFromEnd` and `Line3D.pointAtDistanceFromEnd`, finding a point at a given distance from the line end, going towards the start.
 - Added `Polyline2D.checkForDuplicatePoints` and `Polyline3D.checkForDuplicatePoints`, which return the original polyline when unchanged or a cleaned polyline and reported duplicate points.
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified the docstrings of `Box.MoveX/Y/Z`, `Rect2D.MoveX/Y`, and `Rect3D.MoveX/Y/Z` (instance and static) to state that they move along the **world** X/Y/Z axes, not the shape's own (possibly rotated) local axes. Use `translateLocalX/Y/Z` for local-axis moves.
 
 ### Deprecated
+- All members with a `set` prefix that return a new value instead of mutating are obsolete, use the `with`-prefixed member of the same name instead. The `set` prefix suggested in-place mutation, which these never did. This affects `Pt.setX/setY`, `Pnt.setX/setY/setZ`, `Vc.setX/setY`, `Vec.setX/setY/setZ`, `Line2D.setStart/setFrom/setEnd/setTo`, `Line3D.setStart/setFrom/setEnd/setTo`, `PPlane.setOrigin/setOriginX/setOriginY/setOriginZ`, and `Quaternion.SetAngleInRadians/SetAngleInDegrees` (plus the static `setAngleInRadians`/`setAngleInDegrees`). The genuinely mutating `Set` members on `Polyline2D`, `Polyline3D`, `FreeBox`, and `ResizeArr` are unchanged.
 - `Box.translate`, `Rect2D.translate`, `Rect3D.translate`, and `PPlane.translate` are obsolete. They were plain aliases for `.move` (a world-space vector translation), which is ambiguous alongside the local-axis `translateLocalX/Y/Z` members on the same types. Use `.move` (or `PPlane.translateBy`) for a world-space vector, or `.translateLocalX/Y/Z` to move along the shape's own axes.
 
 ## [0.51.0] - 2026-07-28

--- a/Src/Quaternion.fs
+++ b/Src/Quaternion.fs
@@ -144,10 +144,10 @@ type Quaternion =
 
     /// Get a new Quaternion that rotates around the same axis but with a different angle. In radians.
     /// Fails for identity or near-identity quaternions where the rotation axis is not defined (angle ≈ 0).
-    member q.SetAngleInRadians (angleInRadians:float) : Quaternion =
+    member q.WithAngleInRadians (angleInRadians:float) : Quaternion =
         let length = sqrt(q.X*q.X + q.Y*q.Y + q.Z*q.Z)
         if isTooTiny(length) then
-            fail $"Quaternion.setAngleInRadians failed. The length of the axis is too short: {q.Axis}"
+            fail $"Quaternion.withAngleInRadians failed. The length of the axis is too short: {q.Axis}"
         let sc = 1. / length // inverse for unitizing vector:
         let angHalf = angleInRadians * 0.5
         let sa = sc * sin angHalf
@@ -157,18 +157,19 @@ type Quaternion =
                      cos angHalf )
 
     /// Returns a quaternion with the same rotation axis and the specified angle in radians.
-    static member inline setAngleInRadians (angleInRadians:float) (q:Quaternion) : Quaternion =
-        q.SetAngleInRadians angleInRadians
+    /// Fails for identity or near-identity quaternions where the rotation axis is not defined (angle ≈ 0).
+    static member inline withAngleInRadians (angleInRadians:float) (q:Quaternion) : Quaternion =
+        q.WithAngleInRadians angleInRadians
 
     /// Get a new Quaternion that rotates around the same axis but with a different angle. In degrees.
     /// Fails for identity or near-identity quaternions where the rotation axis is not defined (angle ≈ 0).
-    member inline q.SetAngleInDegrees (angleInDegrees:float) : Quaternion =
-        q.SetAngleInRadians (toRadians angleInDegrees)
+    member inline q.WithAngleInDegrees (angleInDegrees:float) : Quaternion =
+        q.WithAngleInRadians (toRadians angleInDegrees)
 
     /// Get a new Quaternion that rotates around the same axis but with a different angle. In degrees.
     /// Fails for identity or near-identity quaternions where the rotation axis is not defined (angle ≈ 0).
-    static member inline setAngleInDegrees (angleInDegrees:float) (q:Quaternion) : Quaternion =
-        q.SetAngleInRadians (toRadians angleInDegrees)
+    static member inline withAngleInDegrees (angleInDegrees:float) (q:Quaternion) : Quaternion =
+        q.WithAngleInRadians (toRadians angleInDegrees)
 
     (* TODO the interpolation follows a Cone. is that correct ?
 
@@ -575,6 +576,26 @@ type Quaternion =
     [<Obsolete("The Magnitude is always one. This function only exist for testing.")>]
     member q.Magnitude : float =
         sqrt (q.X*q.X + q.Y*q.Y + q.Z*q.Z + q.W*q.W)
+
+    /// Obsolete name. Same as q.WithAngleInRadians.
+    [<Obsolete("Use q.WithAngleInRadians instead. This returns a new Quaternion, it does not mutate, so the 'With' prefix is clearer.")>]
+    member inline q.SetAngleInRadians (angleInRadians:float) : Quaternion =
+        q.WithAngleInRadians angleInRadians
+
+    /// Obsolete name. Same as Quaternion.withAngleInRadians.
+    [<Obsolete("Use Quaternion.withAngleInRadians instead. This returns a new Quaternion, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setAngleInRadians (angleInRadians:float) (q:Quaternion) : Quaternion =
+        q.WithAngleInRadians angleInRadians
+
+    /// Obsolete name. Same as q.WithAngleInDegrees.
+    [<Obsolete("Use q.WithAngleInDegrees instead. This returns a new Quaternion, it does not mutate, so the 'With' prefix is clearer.")>]
+    member inline q.SetAngleInDegrees (angleInDegrees:float) : Quaternion =
+        q.WithAngleInRadians (toRadians angleInDegrees)
+
+    /// Obsolete name. Same as Quaternion.withAngleInDegrees.
+    [<Obsolete("Use Quaternion.withAngleInDegrees instead. This returns a new Quaternion, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setAngleInDegrees (angleInDegrees:float) (q:Quaternion) : Quaternion =
+        q.WithAngleInRadians (toRadians angleInDegrees)
 
 #if !FABLE_COMPILER
 /// Serializes a Quaternion as its X, Y, Z, and W components with System.Text.Json.

--- a/Src/TypeExtensions/Line2D.fs
+++ b/Src/TypeExtensions/Line2D.fs
@@ -1273,24 +1273,24 @@ module AutoOpenLine2D =
     static member inline asFSharpCode (l:Line2D) : string =
         l.AsFSharpCode
 
-    /// Set Line2D start point, returns a new line.
-    /// Same as Line2D.setFrom.
-    static member inline setStart (pt:Pt) (ln:Line2D) : Line2D =
+    /// Returns a new 2D line with a new start point, the end point stays the same.
+    /// Same as Line2D.withFrom.
+    static member inline withStart (pt:Pt) (ln:Line2D) : Line2D =
         Line2D( pt.X, pt.Y, ln.ToX, ln.ToY)
 
-    /// Set Line2D start point, returns a new line.
-    /// Same as Line2D.setStart.
-    static member inline setFrom (pt:Pt) (ln:Line2D) : Line2D =
+    /// Returns a new 2D line with a new start point, the end point stays the same.
+    /// Same as Line2D.withStart.
+    static member inline withFrom (pt:Pt) (ln:Line2D) : Line2D =
         Line2D( pt.X, pt.Y, ln.ToX, ln.ToY)
 
-    /// Set Line2D end point, returns a new line.
-    /// Same as Line2D.setTo.
-    static member inline setEnd (pt:Pt) (ln:Line2D) : Line2D =
+    /// Returns a new 2D line with a new end point, the start point stays the same.
+    /// Same as Line2D.withTo.
+    static member inline withEnd (pt:Pt) (ln:Line2D) : Line2D =
         Line2D( ln.FromX, ln.FromY, pt.X, pt.Y)
 
-    /// Set Line2D end point, returns a new line.
-    /// Same as Line2D.setEnd.
-    static member inline setTo (pt:Pt) (ln:Line2D) : Line2D =
+    /// Returns a new 2D line with a new end point, the start point stays the same.
+    /// Same as Line2D.withEnd.
+    static member inline withTo (pt:Pt) (ln:Line2D) : Line2D =
         Line2D( ln.FromX, ln.FromY, pt.X, pt.Y)
 
     /// Same as ln.Vector or ln.Tangent.
@@ -1661,7 +1661,7 @@ module AutoOpenLine2D =
                 let ye = y + vy*ef
                 lns.[i] <- Line2D(xs,ys,xe,ye)
             // correct last point to avoid numerical errors
-            lns.[segments-1] <- Line2D.setEnd ln.To lns.[segments-1]
+            lns.[segments-1] <- Line2D.withEnd ln.To lns.[segments-1]
             lns
 
     /// Divides a 2D line into as many as segments as possible respecting the minimum segment length and the gap.
@@ -2014,6 +2014,26 @@ module AutoOpenLine2D =
 
     // #endregion
     // #region Obsolete
+
+    /// Obsolete name. Same as Line2D.withStart.
+    [<Obsolete("Use Line2D.withStart instead. This returns a new 2D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setStart (pt:Pt) (ln:Line2D) : Line2D =
+        Line2D( pt.X, pt.Y, ln.ToX, ln.ToY)
+
+    /// Obsolete name. Same as Line2D.withFrom.
+    [<Obsolete("Use Line2D.withFrom instead. This returns a new 2D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setFrom (pt:Pt) (ln:Line2D) : Line2D =
+        Line2D( pt.X, pt.Y, ln.ToX, ln.ToY)
+
+    /// Obsolete name. Same as Line2D.withEnd.
+    [<Obsolete("Use Line2D.withEnd instead. This returns a new 2D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setEnd (pt:Pt) (ln:Line2D) : Line2D =
+        Line2D( ln.FromX, ln.FromY, pt.X, pt.Y)
+
+    /// Obsolete name. Same as Line2D.withTo.
+    [<Obsolete("Use Line2D.withTo instead. This returns a new 2D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setTo (pt:Pt) (ln:Line2D) : Line2D =
+        Line2D( ln.FromX, ln.FromY, pt.X, pt.Y)
 
 
     // Instance members marked as Obsolete that have direct replacements:

--- a/Src/TypeExtensions/Line3D.fs
+++ b/Src/TypeExtensions/Line3D.fs
@@ -1665,24 +1665,24 @@ module AutoOpenLine3D =
     static member inline toZ (l:Line3D) : float =
         l.ToZ
 
-    /// Set Line3D start point, returns a new line.
-    /// Same as Line3D.setFrom.
-    static member inline setStart (pt:Pnt) (ln:Line3D) : Line3D =
+    /// Returns a new 3D line with a new start point, the end point stays the same.
+    /// Same as Line3D.withFrom.
+    static member inline withStart (pt:Pnt) (ln:Line3D) : Line3D =
         Line3D(pt.X, pt.Y, pt.Z, ln.ToX, ln.ToY, ln.ToZ)
 
-    /// Set Line3D start point, returns a new line.
-    /// Same as Line3D.setStart.
-    static member inline setFrom (pt:Pnt) (ln:Line3D) : Line3D =
+    /// Returns a new 3D line with a new start point, the end point stays the same.
+    /// Same as Line3D.withStart.
+    static member inline withFrom (pt:Pnt) (ln:Line3D) : Line3D =
         Line3D(pt.X, pt.Y, pt.Z, ln.ToX, ln.ToY, ln.ToZ)
 
-    /// Set Line3D end point, returns a new line.
-    /// Same as Line3D.setTo.
-    static member inline setEnd (pt:Pnt) (ln:Line3D) : Line3D =
+    /// Returns a new 3D line with a new end point, the start point stays the same.
+    /// Same as Line3D.withTo.
+    static member inline withEnd (pt:Pnt) (ln:Line3D) : Line3D =
         Line3D(ln.FromX, ln.FromY, ln.FromZ, pt.X, pt.Y, pt.Z)
 
-    /// Set Line3D end point, returns a new line.
-    /// Same as Line3D.setEnd.
-    static member inline setTo (pt:Pnt) (ln:Line3D) : Line3D =
+    /// Returns a new 3D line with a new end point, the start point stays the same.
+    /// Same as Line3D.withEnd.
+    static member inline withTo (pt:Pnt) (ln:Line3D) : Line3D =
         Line3D(ln.FromX, ln.FromY, ln.FromZ, pt.X, pt.Y, pt.Z)
 
     /// Returns the length of the line.
@@ -2042,7 +2042,7 @@ module AutoOpenLine3D =
                 let ze = z + vz*ef
                 lns.[i] <- Line3D(xs,ys,zs,xe,ye,ze)
             // correct last point to avoid numerical errors
-            lns.[segments-1] <- Line3D.setEnd ln.To lns.[segments-1]
+            lns.[segments-1] <- Line3D.withEnd ln.To lns.[segments-1]
             lns
 
     /// Divides a 3D line into as many as segments as possible respecting the minimum segment length and the gap.
@@ -2438,6 +2438,26 @@ module AutoOpenLine3D =
 
     // #endregion
     // #region Obsolete
+
+    /// Obsolete name. Same as Line3D.withStart.
+    [<Obsolete("Use Line3D.withStart instead. This returns a new 3D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setStart (pt:Pnt) (ln:Line3D) : Line3D =
+        Line3D(pt.X, pt.Y, pt.Z, ln.ToX, ln.ToY, ln.ToZ)
+
+    /// Obsolete name. Same as Line3D.withFrom.
+    [<Obsolete("Use Line3D.withFrom instead. This returns a new 3D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setFrom (pt:Pnt) (ln:Line3D) : Line3D =
+        Line3D(pt.X, pt.Y, pt.Z, ln.ToX, ln.ToY, ln.ToZ)
+
+    /// Obsolete name. Same as Line3D.withEnd.
+    [<Obsolete("Use Line3D.withEnd instead. This returns a new 3D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setEnd (pt:Pnt) (ln:Line3D) : Line3D =
+        Line3D(ln.FromX, ln.FromY, ln.FromZ, pt.X, pt.Y, pt.Z)
+
+    /// Obsolete name. Same as Line3D.withTo.
+    [<Obsolete("Use Line3D.withTo instead. This returns a new 3D line, it does not mutate, so the 'with' prefix is clearer.")>]
+    static member inline setTo (pt:Pnt) (ln:Line3D) : Line3D =
+        Line3D(ln.FromX, ln.FromY, ln.FromZ, pt.X, pt.Y, pt.Z)
 
 
 

--- a/Src/TypeExtensions/PPlane.fs
+++ b/Src/TypeExtensions/PPlane.fs
@@ -414,20 +414,20 @@ module AutoOpenPPlane =
             //abs (a.ZaxisY - b.ZaxisY) <= tol &&
             //abs (a.ZaxisZ - b.ZaxisZ) <= tol
 
-        /// Returns a new plane with given Origin.
-        static member inline setOrigin (pt:Pnt) (pl:PPlane) : PPlane =
+        /// Returns a new plane with given Origin. The axes stay the same.
+        static member inline withOrigin (pt:Pnt) (pl:PPlane) : PPlane =
             PPlane.createUnchecked(pt.X, pt.Y, pt.Z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
-        /// Returns a new plane with given Origin X value changed.
-        static member inline setOriginX (x:float) (pl:PPlane) : PPlane =
+        /// Returns a new plane with given Origin X value changed. The axes stay the same.
+        static member inline withOriginX (x:float) (pl:PPlane) : PPlane =
             PPlane.createUnchecked(x, pl.OriginY, pl.OriginZ, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
-        /// Returns a new plane with given Origin Y value changed.
-        static member inline setOriginY (y:float) (pl:PPlane) : PPlane =
+        /// Returns a new plane with given Origin Y value changed. The axes stay the same.
+        static member inline withOriginY (y:float) (pl:PPlane) : PPlane =
             PPlane.createUnchecked(pl.OriginX, y, pl.OriginZ, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
-        /// Returns a new plane with given Origin Z value changed.
-        static member inline setOriginZ (z:float) (pl:PPlane) : PPlane =
+        /// Returns a new plane with given Origin Z value changed. The axes stay the same.
+        static member inline withOriginZ (z:float) (pl:PPlane) : PPlane =
             PPlane.createUnchecked(pl.OriginX, pl.OriginY, z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 
         /// Returns a new plane with Origin translated by Vec.
@@ -622,4 +622,24 @@ module AutoOpenPPlane =
         [<Obsolete("rename to PPlane.transformRigid for clarity")>]
         static member transform (m:RigidMatrix) (pl:PPlane) : PPlane =
             PPlane.transformRigid m pl
+
+        /// Obsolete name. Same as PPlane.withOrigin.
+        [<Obsolete("Use PPlane.withOrigin instead. This returns a new plane, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setOrigin (pt:Pnt) (pl:PPlane) : PPlane =
+            PPlane.createUnchecked(pt.X, pt.Y, pt.Z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
+
+        /// Obsolete name. Same as PPlane.withOriginX.
+        [<Obsolete("Use PPlane.withOriginX instead. This returns a new plane, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setOriginX (x:float) (pl:PPlane) : PPlane =
+            PPlane.createUnchecked(x, pl.OriginY, pl.OriginZ, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
+
+        /// Obsolete name. Same as PPlane.withOriginY.
+        [<Obsolete("Use PPlane.withOriginY instead. This returns a new plane, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setOriginY (y:float) (pl:PPlane) : PPlane =
+            PPlane.createUnchecked(pl.OriginX, y, pl.OriginZ, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
+
+        /// Obsolete name. Same as PPlane.withOriginZ.
+        [<Obsolete("Use PPlane.withOriginZ instead. This returns a new plane, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setOriginZ (z:float) (pl:PPlane) : PPlane =
+            PPlane.createUnchecked(pl.OriginX, pl.OriginY, z, pl.XaxisX, pl.XaxisY, pl.XaxisZ, pl.YaxisX, pl.YaxisY, pl.YaxisZ, pl.ZaxisX, pl.ZaxisY, pl.ZaxisZ)
 

--- a/Src/TypeExtensions/Pnt.fs
+++ b/Src/TypeExtensions/Pnt.fs
@@ -81,7 +81,6 @@ module AutoOpenPnt =
             Pnt (x, pt.Y, pt.Z)
 
         /// Returns new 3D point with new X coordinate, Y and Z stay the same.
-        /// Same as Pnt.setX.
         static member inline withX x (pt:Pnt) : Pnt =
             Pnt(x, pt.Y, pt.Z)
 
@@ -90,7 +89,6 @@ module AutoOpenPnt =
             Pnt (pt.X, y, pt.Z)
 
         /// Returns a new 3D point with new Y coordinate, X and Z stay the same.
-        /// Same as Pnt.setY.
         static member inline withY y (pt:Pnt) : Pnt =
             Pnt(pt.X, y, pt.Z)
 
@@ -99,7 +97,6 @@ module AutoOpenPnt =
             Pnt (pt.X, pt.Y, z)
 
         /// Returns a new 3D point with new Z coordinate, X and Y stay the same.
-        /// Same as Pnt.setZ.
         static member inline withZ z (pt:Pnt) : Pnt =
             Pnt(pt.X, pt.Y, z)
 
@@ -408,21 +405,6 @@ module AutoOpenPnt =
         static member inline getZ (pt:Pnt) : float =
             pt.Z
 
-        /// Returns a new 3D point with new X coordinate, Y and Z stay the same.
-        /// Same as Pnt.withX.
-        static member inline setX (x:float) (pt:Pnt) : Pnt =
-            Pnt(x, pt.Y, pt.Z)
-
-        /// Returns a new 3D point with new Y coordinate, X and Z stay the same.
-        /// Same as Pnt.withY.
-        static member inline setY (y:float) (pt:Pnt) : Pnt =
-            Pnt(pt.X, y, pt.Z)
-
-        /// Returns a new 3D point with new Z coordinate, X and Y stay the same.
-        /// Same as Pnt.withZ.
-        static member inline setZ (z:float) (pt:Pnt) : Pnt =
-            Pnt(pt.X, pt.Y, z)
-
         /// Adds two 3D points and return new 3D point.
         static member inline add (a:Pnt) (b:Pnt) : Pnt =
             a + b
@@ -708,6 +690,21 @@ module AutoOpenPnt =
 
         // #endregion
         // #region Obsolete
+
+        /// Obsolete name. Same as Pnt.withX.
+        [<Obsolete("Use Pnt.withX instead. This returns a new 3D point, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setX (x:float) (pt:Pnt) : Pnt =
+            Pnt(x, pt.Y, pt.Z)
+
+        /// Obsolete name. Same as Pnt.withY.
+        [<Obsolete("Use Pnt.withY instead. This returns a new 3D point, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setY (y:float) (pt:Pnt) : Pnt =
+            Pnt(pt.X, y, pt.Z)
+
+        /// Obsolete name. Same as Pnt.withZ.
+        [<Obsolete("Use Pnt.withZ instead. This returns a new 3D point, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setZ (z:float) (pt:Pnt) : Pnt =
+            Pnt(pt.X, pt.Y, z)
 
         /// Obsolete typo. Same as p.IsInvalid.
         [<Obsolete("Typo, use IsInvalid instead.")>]

--- a/Src/TypeExtensions/Pt.fs
+++ b/Src/TypeExtensions/Pt.fs
@@ -83,7 +83,6 @@ module AutoOpenPt =
             Pt (x, pt.Y)
 
         /// Returns new 2D point with new X coordinate, Y stays the same.
-        /// Same as Pt.setX.
         static member inline withX x (pt:Pt) : Pt =
             Pt(x, pt.Y)
 
@@ -92,7 +91,6 @@ module AutoOpenPt =
             Pt (pt.X, y)
 
         /// Returns new 2D point with new Y coordinate, X stays the same.
-        /// Same as Pt.setY.
         static member inline withY y (pt:Pt) : Pt =
             Pt(pt.X, y)
 
@@ -414,16 +412,6 @@ module AutoOpenPt =
         static member inline getY (pt:Pt) : float =
             pt.Y
 
-        /// Returns a new 2D point with new X coordinate, Y stays the same.
-        /// Same as Pt.withX.
-        static member inline setX (x:float) (pt:Pt) : Pt =
-            Pt(x, pt.Y)
-
-        /// Returns a new 2D point with new Y coordinate, X stays the same.
-        /// Same as Pt.withY.
-        static member inline setY (y:float) (pt:Pt) : Pt =
-            Pt(pt.X, y)
-
         /// Adds two 2D points. Returns a new 2D point.
         static member inline add (a:Pt) (b:Pt) : Pt =
             a + b
@@ -579,6 +567,16 @@ module AutoOpenPt =
 
         // #endregion
         // #region Obsolete
+
+        /// Obsolete name. Same as Pt.withX.
+        [<Obsolete("Use Pt.withX instead. This returns a new 2D point, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setX (x:float) (pt:Pt) : Pt =
+            Pt(x, pt.Y)
+
+        /// Obsolete name. Same as Pt.withY.
+        [<Obsolete("Use Pt.withY instead. This returns a new 2D point, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setY (y:float) (pt:Pt) : Pt =
+            Pt(pt.X, y)
 
         /// Obsolete typo. Same as p.IsInvalid.
         [<Obsolete("Typo, use IsInvalid instead.")>]

--- a/Src/TypeExtensions/Vc.fs
+++ b/Src/TypeExtensions/Vc.fs
@@ -82,7 +82,6 @@ module AutoOpenVc =
             Vc (x, v.Y)
 
         /// Returns a new 2D vector with new X coordinate, Y stays the same.
-        /// Same as Vc.setX.
         static member inline withX x (v:Vc) : Vc =
             v.WithX x
 
@@ -91,7 +90,6 @@ module AutoOpenVc =
             Vc (v.X, y)
 
         /// Returns a new 2D vector with new Y coordinate, X stays the same.
-        /// Same as Vc.setY.
         static member inline withY y (v:Vc) : Vc =
             v.WithY y
 
@@ -587,16 +585,6 @@ module AutoOpenVc =
         // #endregion
         // #region Static members
 
-        /// Returns a new 2D vector with new X coordinate, Y stays the same.
-        /// Same as Vc.withX.
-        static member inline setX (x:float) (vc:Vc) : Vc =
-            Vc(x, vc.Y)
-
-        /// Returns a new 2D vector with new Y coordinate, X stays the same.
-        /// Same as Vc.withY.
-        static member inline setY (y:float) (vc:Vc) : Vc =
-            Vc(vc.X, y)
-
         /// Returns the World X-axis with length one: Vc(1, 0)
         static member inline Xaxis : Vc =
             Vc(1, 0)
@@ -943,6 +931,16 @@ module AutoOpenVc =
 
         // #endregion
         // #region Obsolete
+
+        /// Obsolete name. Same as Vc.withX.
+        [<Obsolete("Use Vc.withX instead. This returns a new 2D vector, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setX (x:float) (vc:Vc) : Vc =
+            Vc(x, vc.Y)
+
+        /// Obsolete name. Same as Vc.withY.
+        [<Obsolete("Use Vc.withY instead. This returns a new 2D vector, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setY (y:float) (vc:Vc) : Vc =
+            Vc(vc.X, y)
 
 
         [<Obsolete("Use Vc.isParallelWithin instead.")>]

--- a/Src/TypeExtensions/Vec.fs
+++ b/Src/TypeExtensions/Vec.fs
@@ -93,7 +93,6 @@ module AutoOpenVec =
             Vec (x, v.Y, v.Z)
 
         /// Returns a new 3D vector with new X coordinate, Y and Z stay the same.
-        /// Same as Vec.setX.
         static member inline withX  x (v:Vec) : Vec =
             v.WithX x
 
@@ -102,7 +101,6 @@ module AutoOpenVec =
             Vec (v.X, y, v.Z)
 
         /// Returns a new 3D vector with new y coordinate, X and Z stay the same.
-        /// Same as Vec.setY.
         static member inline withY  y (v:Vec) : Vec =
             v.WithY y
 
@@ -111,7 +109,6 @@ module AutoOpenVec =
             Vec (v.X, v.Y, z)
 
         /// Returns a new 3D vector with new z coordinate, X and Y stay the same.
-        /// Same as Vec.setZ.
         static member inline withZ z (v:Vec) : Vec =
             v.WithZ z
 
@@ -758,21 +755,6 @@ module AutoOpenVec =
         static member inline getZ (v:Vec) : float =
             v.Z
 
-        /// Returns a new 3D vector with new X coordinate, Y and Z stay the same.
-        /// Same as Vec.withX.
-        static member inline setX (x:float) (v:Vec) : Vec =
-            Vec(x, v.Y, v.Z)
-
-        /// Returns a new 3D vector with new Y coordinate, X and Z stay the same.
-        /// Same as Vec.withY.
-        static member inline setY (y:float) (v:Vec) : Vec =
-            Vec(v.X, y, v.Z)
-
-        /// Returns a new 3D vector with new Z coordinate, X and Y stay the same.
-        /// Same as Vec.withZ.
-        static member inline setZ (z:float) (v:Vec) : Vec =
-            Vec(v.X, v.Y, z)
-
         /// Add two 3D vectors together. Returns a new 3D vector.
         static member inline add (a:Vec) (b:Vec) : Vec =
             Vec (a.X + b.X, a.Y + b.Y, a.Z + b.Z)
@@ -1119,6 +1101,21 @@ module AutoOpenVec =
 
         // #endregion
         // #region Obsolete
+
+        /// Obsolete name. Same as Vec.withX.
+        [<Obsolete("Use Vec.withX instead. This returns a new 3D vector, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setX (x:float) (v:Vec) : Vec =
+            Vec(x, v.Y, v.Z)
+
+        /// Obsolete name. Same as Vec.withY.
+        [<Obsolete("Use Vec.withY instead. This returns a new 3D vector, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setY (y:float) (v:Vec) : Vec =
+            Vec(v.X, y, v.Z)
+
+        /// Obsolete name. Same as Vec.withZ.
+        [<Obsolete("Use Vec.withZ instead. This returns a new 3D vector, it does not mutate, so the 'with' prefix is clearer.")>]
+        static member inline setZ (z:float) (v:Vec) : Vec =
+            Vec(v.X, v.Y, z)
 
         [<Obsolete("Use Vec.isParallelWithin instead.")>]
         static member inline isAngle90Below (cosineValue: float<Cosine.cosine>) (a:Vec) (b:Vec) : bool =

--- a/Test/TestLine.fs
+++ b/Test/TestLine.fs
@@ -1450,6 +1450,46 @@ let testsLine2DOffset =
     ]
 
 
+let testsLine2DWithStartEnd =
+    testList "Line2D WithStart / WithEnd" [
+
+        test "withStart replaces the start point only" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let result = Line2D.withStart (Pt(1., 2.)) ln
+            "new start" |> Expect.isTrue (eq result.From (Pt(1., 2.)))
+            "end unchanged" |> Expect.isTrue (eq result.To ln.To)
+            "input unchanged" |> Expect.isTrue (eq ln.From (Pt(0., 0.)))
+        }
+
+        test "withFrom is the same as withStart" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let a = Line2D.withStart (Pt(1., 2.)) ln
+            let b = Line2D.withFrom (Pt(1., 2.)) ln
+            "withFrom equals withStart" |> Expect.isTrue (eq a.From b.From && eq a.To b.To)
+        }
+
+        test "withEnd replaces the end point only" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let result = Line2D.withEnd (Pt(3., 4.)) ln
+            "start unchanged" |> Expect.isTrue (eq result.From ln.From)
+            "new end" |> Expect.isTrue (eq result.To (Pt(3., 4.)))
+            "input unchanged" |> Expect.isTrue (eq ln.To (Pt(10., 0.)))
+        }
+
+        test "withTo is the same as withEnd" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let a = Line2D.withEnd (Pt(3., 4.)) ln
+            let b = Line2D.withTo (Pt(3., 4.)) ln
+            "withTo equals withEnd" |> Expect.isTrue (eq a.From b.From && eq a.To b.To)
+        }
+
+        test "withStart to the end point gives a zero length line" {
+            let ln = Line2D(0., 0., 10., 0.)
+            let result = Line2D.withStart ln.To ln
+            "zero length" |> expectEqualEpsilon result.Length 0.
+        }
+    ]
+
 let testsLine2DWithLength =
     testList "Line2D WithLength Methods" [
 
@@ -2520,6 +2560,46 @@ let testsLine3DOffset =
     ]
 
 
+let testsLine3DWithStartEnd =
+    testList "Line3D WithStart / WithEnd" [
+
+        test "withStart replaces the start point only" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let result = Line3D.withStart (Pnt(1., 2., 3.)) ln
+            "new start" |> Expect.isTrue (Pnt.dist result.From (Pnt(1., 2., 3.)) < 1e-9)
+            "end unchanged" |> Expect.isTrue (Pnt.dist result.To ln.To < 1e-9)
+            "input unchanged" |> Expect.isTrue (Pnt.dist ln.From Pnt.Origin < 1e-9)
+        }
+
+        test "withFrom is the same as withStart" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let a = Line3D.withStart (Pnt(1., 2., 3.)) ln
+            let b = Line3D.withFrom (Pnt(1., 2., 3.)) ln
+            "withFrom equals withStart" |> Expect.isTrue (Pnt.dist a.From b.From < 1e-9 && Pnt.dist a.To b.To < 1e-9)
+        }
+
+        test "withEnd replaces the end point only" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let result = Line3D.withEnd (Pnt(4., 5., 6.)) ln
+            "start unchanged" |> Expect.isTrue (Pnt.dist result.From ln.From < 1e-9)
+            "new end" |> Expect.isTrue (Pnt.dist result.To (Pnt(4., 5., 6.)) < 1e-9)
+            "input unchanged" |> Expect.isTrue (Pnt.dist ln.To (Pnt(10., 0., 0.)) < 1e-9)
+        }
+
+        test "withTo is the same as withEnd" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let a = Line3D.withEnd (Pnt(4., 5., 6.)) ln
+            let b = Line3D.withTo (Pnt(4., 5., 6.)) ln
+            "withTo equals withEnd" |> Expect.isTrue (Pnt.dist a.From b.From < 1e-9 && Pnt.dist a.To b.To < 1e-9)
+        }
+
+        test "withEnd to the start point gives a zero length line" {
+            let ln = Line3D(0., 0., 0., 10., 0., 0.)
+            let result = Line3D.withEnd ln.From ln
+            "zero length" |> expectEqualEpsilon result.Length 0.
+        }
+    ]
+
 let testsLine3DWithLength =
     testList "Line3D WithLength Methods" [
 
@@ -3286,6 +3366,7 @@ let tests =
         testsLine2DProjection
         testsLine2DDivide
         testsLine2DOffset
+        testsLine2DWithStartEnd
         testsLine2DWithLength
         testsLine2DIntersection
         testsFastParallel3D
@@ -3296,6 +3377,7 @@ let tests =
         testsLine3DProjection
         testsLine3DDivide
         testsLine3DOffset
+        testsLine3DWithStartEnd
         testsLine3DWithLength
         testsLine3DIntersection
         testsLine3DDistance

--- a/Test/TestPlane.fs
+++ b/Test/TestPlane.fs
@@ -552,6 +552,43 @@ let tests =
             }
         ]
 
+        testList "PPlane - WithOrigin" [
+            test "withOrigin moves the origin and keeps the axes" {
+                let pl = PPlane.WorldXY
+                let moved = PPlane.withOrigin (Pnt(1., 2., 3.)) pl
+                Expect.isTrue (eqPnt moved.Origin (Pnt(1., 2., 3.))) "Origin should be the given point"
+                Expect.isTrue (eqVec moved.Xaxis.AsVec pl.Xaxis.AsVec) "Xaxis should be unchanged"
+                Expect.isTrue (eqVec moved.Yaxis.AsVec pl.Yaxis.AsVec) "Yaxis should be unchanged"
+                Expect.isTrue (eqVec moved.Zaxis.AsVec pl.Zaxis.AsVec) "Zaxis should be unchanged"
+                Expect.isTrue (eqPnt pl.Origin Pnt.Origin) "Input plane should be unchanged"
+            }
+
+            test "withOriginX changes only the X value of the origin" {
+                let pl = PPlane.withOrigin (Pnt(1., 2., 3.)) PPlane.WorldXY
+                let moved = PPlane.withOriginX 9. pl
+                Expect.isTrue (eqPnt moved.Origin (Pnt(9., 2., 3.))) "Only X should change"
+            }
+
+            test "withOriginY changes only the Y value of the origin" {
+                let pl = PPlane.withOrigin (Pnt(1., 2., 3.)) PPlane.WorldXY
+                let moved = PPlane.withOriginY 9. pl
+                Expect.isTrue (eqPnt moved.Origin (Pnt(1., 9., 3.))) "Only Y should change"
+            }
+
+            test "withOriginZ changes only the Z value of the origin" {
+                let pl = PPlane.withOrigin (Pnt(1., 2., 3.)) PPlane.WorldXY
+                let moved = PPlane.withOriginZ 9. pl
+                Expect.isTrue (eqPnt moved.Origin (Pnt(1., 2., 9.))) "Only Z should change"
+            }
+
+            test "withOrigin on a rotated plane keeps the rotated axes" {
+                let pl = PPlane.createOriginXaxisYaxis(Pnt(5., 5., 5.), Vec(0., 1., 0.), Vec(-1., 0., 0.))
+                let moved = PPlane.withOrigin Pnt.Origin pl
+                Expect.isTrue (eqPnt moved.Origin Pnt.Origin) "Origin should be at world origin"
+                Expect.isTrue (eqVec moved.Xaxis.AsVec (Vec(0., 1., 0.))) "Xaxis should stay rotated"
+            }
+        ]
+
         testList "PPlane - Projection and Closest Point" [
             test "ClosestPoint on plane" {
                 let plane = PPlane.WorldXY

--- a/Test/TestQuat.fs
+++ b/Test/TestQuat.fs
@@ -112,9 +112,9 @@ let tests =
             Expect.floatClose Accuracy.high q.AngleInRadians (System.Math.PI / 3.0) "angle in radians"
         }
 
-        test "Quaternion set angle" {
+        test "Quaternion with angle" {
             let q = Quaternion.createFromDegrees(Vec.Zaxis, 90.)
-            let q2 = q.SetAngleInDegrees(45.)
+            let q2 = q.WithAngleInDegrees(45.)
             let a = Pnt(1,0,0)
             let result = a *** q2
             let sqrt2_2 = sqrt(2.0) / 2.0
@@ -220,15 +220,36 @@ let tests =
             Expect.throws (fun () -> Quaternion.createFromDegrees(tinyAxis, 45.) |> ignore) "very short axis should fail"
         }
 
-        test "Quaternion setAngle on identity should fail" {
-            let q = Quaternion.identity
-            Expect.throws (fun () -> q.SetAngleInRadians 1.0 |> ignore) "setAngle on identity should fail"
-            Expect.throws (fun () -> q.SetAngleInDegrees 45. |> ignore) "setAngle on identity should fail"
+        test "Quaternion withAngle static members match instance members" {
+            let q = Quaternion.createFromDegrees(Vec.Zaxis, 90.)
+            let a = Quaternion.withAngleInDegrees 45. q
+            let b = q.WithAngleInDegrees 45.
+            let c = Quaternion.withAngleInRadians (System.Math.PI * 0.25) q
+            Expect.floatClose Accuracy.high a.AngleInDegrees 45.0 "static withAngleInDegrees"
+            Expect.floatClose Accuracy.high b.AngleInDegrees 45.0 "instance WithAngleInDegrees"
+            Expect.floatClose Accuracy.high c.AngleInDegrees 45.0 "static withAngleInRadians"
+            Expect.floatClose Accuracy.high q.AngleInDegrees 90.0 "input quaternion is unchanged"
         }
 
-        test "Quaternion setAngle on near-identity should fail" {
+        test "Quaternion withAngle keeps the rotation axis" {
+            let axis = Vec(1., 2., 3.)
+            let q = Quaternion.createFromDegrees(axis, 30.)
+            let q2 = q.WithAngleInDegrees 120.
+            Expect.floatClose Accuracy.high q2.AngleInDegrees 120.0 "new angle"
+            let a1 = Vec.unitize q.Axis
+            let a2 = Vec.unitize q2.Axis
+            Expect.isTrue (Vec.length (a1.AsVec - a2.AsVec) < 1e-9) "axis stays the same"
+        }
+
+        test "Quaternion withAngle on identity should fail" {
+            let q = Quaternion.identity
+            Expect.throws (fun () -> q.WithAngleInRadians 1.0 |> ignore) "withAngle on identity should fail"
+            Expect.throws (fun () -> q.WithAngleInDegrees 45. |> ignore) "withAngle on identity should fail"
+        }
+
+        test "Quaternion withAngle on near-identity should fail" {
             let q = Quaternion.createFromDegrees(Vec.Zaxis, 1e-10)
-            Expect.throws (fun () -> q.SetAngleInRadians 1.0 |> ignore) "setAngle on near-identity should fail"
+            Expect.throws (fun () -> q.WithAngleInRadians 1.0 |> ignore) "withAngle on near-identity should fail"
         }
 
         test "Quaternion Axis on identity returns zero vector" {


### PR DESCRIPTION
## Summary
Renamed all methods with `set` prefix to use `with` prefix across multiple types to better reflect that these methods return new values rather than mutating the original objects. The old `set*` methods are now marked as obsolete with deprecation warnings directing users to the new `with*` equivalents.

## Key Changes

- **Line2D**: Renamed `setStart`/`setFrom`/`setEnd`/`setTo` to `withStart`/`withFrom`/`withEnd`/`withTo`
- **Line3D**: Renamed `setStart`/`setFrom`/`setEnd`/`setTo` to `withStart`/`withFrom`/`withEnd`/`withTo`
- **Quaternion**: Renamed `SetAngleInRadians`/`SetAngleInDegrees` (instance) and `setAngleInRadians`/`setAngleInDegrees` (static) to `WithAngleInRadians`/`WithAngleInDegrees` and `withAngleInRadians`/`withAngleInDegrees`
- **PPlane**: Renamed `setOrigin`/`setOriginX`/`setOriginY`/`setOriginZ` to `withOrigin`/`withOriginX`/`withOriginY`/`withOriginZ`
- **Pnt**: Renamed `setX`/`setY`/`setZ` to `withX`/`withY`/`withZ`
- **Vec**: Renamed `setX`/`setY`/`setZ` to `withX`/`withY`/`withZ`
- **Pt**: Renamed `setX`/`setY` to `withX`/`withY`
- **Vc**: Renamed `setX`/`setY` to `withX`/`withY`

## Implementation Details

- Old `set*` methods are preserved as obsolete members with `[<Obsolete>]` attributes that direct users to the new `with*` equivalents
- Updated all internal usages within the codebase to use the new `with*` method names
- Added comprehensive test coverage for the new `with*` methods in `TestLine.fs`, `TestPlane.fs`, and `TestQuat.fs`
- Updated XML documentation comments to clarify that these methods return new values and that axes/endpoints stay the same
- Removed redundant "Same as..." documentation from `with*` methods in Pnt, Vec, Pt, and Vc since they are now the primary methods

https://claude.ai/code/session_014kQFHp5vd5jbGuCJk9uH8b